### PR TITLE
Add core units

### DIFF
--- a/versions/v1/unitSystems.json
+++ b/versions/v1/unitSystems.json
@@ -19,8 +19,8 @@
                 "unitExternalId": "volume:m3"
             },
             {
-                "name": "Percent",
-                "unitExternalId": "percent:percent"
+                "name": "Fraction",
+                "unitExternalId": "fraction:percent"
             },
             {
                 "name": "Mass",

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -1022,14 +1022,14 @@
         "sourceReference": "http://qudt.org/vocab/unit/BBL_US"
     },
     {
-        "externalId": "percent:percent",
+        "externalId": "fraction:percent",
         "name": "%",
         "longName": "Percent",
         "aliasNames": [
             "%",
             "Percent"
         ],
-        "quantity": "Percent",
+        "quantity": "Fraction",
         "conversion": {
             "multiplier": 1.0,
             "offset": 0.0
@@ -1038,13 +1038,13 @@
         "sourceReference": null
     },
     {
-        "externalId": "percent:fraction",
+        "externalId": "fraction:fraction",
         "name": "fraction",
         "longName": "Fraction",
         "aliasNames": [
             "fraction"
         ],
-        "quantity": "Percent",
+        "quantity": "Fraction",
         "conversion": {
             "multiplier": 0.01,
             "offset": 0.0


### PR DESCRIPTION
This PR adds some of the core units needed by our customers.

On Pressure, there are two ways to refer to a measurement:
- absolute
- gauge (difference compared to atmospheric pressure)

A unit with no absolute vs gauge specification is assumed to be in absolute state, so all items added are considered to be absolute. We'll have to add the gauge counterparts, by replicating the absolute items and applying the following formula `Absolute pressure = gauge pressure + atmospheric pressure`.

The name for each gauge item will be terminated by a `g`, like `psig` for the `psi` variant.

I haven't spent the time to add the aliases yet. That will come in a future PR.