### PR TITLE
Remove duplicate alias (Mass: t)

### DIFF
--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -1249,7 +1249,6 @@
         "name": "t",
         "longName": "Tonne",
         "aliasNames": [
-            "t",
             "Tonne"
         ],
         "quantity": "Mass",


### PR DESCRIPTION
t is used as an alias for both mass:tonne and mass:ton_metric