### PR TITLE
add method for listing unit systems

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.cognite.units</groupId>
   <artifactId>units-catalog</artifactId>
-  <version>0.1.4</version>
+  <version>0.1.5</version>
 
   <name>${project.groupId}:${project.artifactId}</name>
   <description>A comprehensive unit catalog for Cognite Data Fusion (CDF) with a focus on standardization, comprehensiveness, and consistency.</description>

--- a/src/main/kotlin/com/cognite/units/UnitService.kt
+++ b/src/main/kotlin/com/cognite/units/UnitService.kt
@@ -172,6 +172,8 @@ class UnitService(unitsPath: URL, systemPath: URL) {
 
     fun getUnits(): List<TypedUnit> = unitsByExternalId.values.toList()
 
+    fun getUnitSystems(): Set<String> = defaultUnitByQuantityAndSystem.keys
+
     fun getUnitByExternalId(externalId: String): TypedUnit {
         return unitsByExternalId[externalId] ?: throw IllegalArgumentException("Unknown unit '$externalId'")
     }

--- a/src/test/kotlin/UnitTest.kt
+++ b/src/test/kotlin/UnitTest.kt
@@ -144,7 +144,8 @@ class UnitTest {
     fun lookupUnitSystem() {
         val unitService = UnitService.service
         assertEquals(
-            setOf("Default", "Imperial", "SI"), unitService.getUnitSystems(),
+            setOf("Default", "Imperial", "SI"),
+            unitService.getUnitSystems(),
         )
     }
 }

--- a/src/test/kotlin/UnitTest.kt
+++ b/src/test/kotlin/UnitTest.kt
@@ -139,4 +139,12 @@ class UnitTest {
             unitService.getUnitsByQuantityAndAlias("Temperature", "unknown")
         }
     }
+
+    @Test
+    fun lookupUnitSystem() {
+        val unitService = UnitService.service
+        assertEquals(
+            setOf("Default", "Imperial", "SI"), unitService.getUnitSystems(),
+        )
+    }
 }


### PR DESCRIPTION
Purpose is to be able to verify that a unit system is valid, before we know which unit to convert.
If someone asks for a unit in the unit system "Unperial", it should fail immediately, preferably with a list of valid unit systems, not wait for the error when it tries to convert any unit to "Unperial".