### PR TITLE
Simplify scala interop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.cognite.units</groupId>
   <artifactId>units-catalog</artifactId>
-  <version>0.1.5</version>
+  <version>0.1.6</version>
 
   <name>${project.groupId}:${project.artifactId}</name>
   <description>A comprehensive unit catalog for Cognite Data Fusion (CDF) with a focus on standardization, comprehensiveness, and consistency.</description>

--- a/src/main/kotlin/com/cognite/units/UnitService.kt
+++ b/src/main/kotlin/com/cognite/units/UnitService.kt
@@ -262,3 +262,8 @@ class UnitService(unitsPath: URL, systemPath: URL) {
         return unitsByExternalId.containsKey(unitExternalId)
     }
 }
+
+// Kotlin shim to simplify interop with Scala
+object UnitServiceFacade {
+    fun getService(): UnitService = UnitService.service
+}


### PR DESCRIPTION
This PR adds a simple helper method to expose the `UnitService` companion object.

It seems we cannot access Kotlin's companion object from Scala to get a hold of a static property of the `UnitService` which already contains all the units from the catalog. What we can do is to use the primary constructor of `UnitService` to instantiate a new object, but for that we need to pass on a reference of the unit-catalog JSON entries, which defeats the purpose of using the library with the embedded catalog.

To simplify this and allow access to the `UnitService` companion object from Scala, we introduce this Kotlin facade that exposes the static property we want in a way should be easily accessible from Scala.