### PR TITLE
Overloading the constructor to load from strings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.cognite.units</groupId>
   <artifactId>units-catalog</artifactId>
-  <version>0.1.8</version>
+  <version>0.1.9</version>
 
   <name>${project.groupId}:${project.artifactId}</name>
   <description>A comprehensive unit catalog for Cognite Data Fusion (CDF) with a focus on standardization, comprehensiveness, and consistency.</description>

--- a/src/main/kotlin/com/cognite/units/UnitService.kt
+++ b/src/main/kotlin/com/cognite/units/UnitService.kt
@@ -28,7 +28,7 @@ import kotlin.math.roundToLong
 
 class UnitService(units: String, systems: String) {
 
-    constructor(unitsPath: URL, systemPath: URL): this(unitsPath.readText(), systemPath.readText())
+    constructor(unitsPath: URL, systemPath: URL) : this(unitsPath.readText(), systemPath.readText())
 
     companion object {
         val service: UnitService by lazy {

--- a/src/main/kotlin/com/cognite/units/UnitService.kt
+++ b/src/main/kotlin/com/cognite/units/UnitService.kt
@@ -26,7 +26,10 @@ import kotlin.math.log10
 import kotlin.math.pow
 import kotlin.math.roundToLong
 
-class UnitService(unitsPath: URL, systemPath: URL) {
+class UnitService(units: String, systems: String) {
+
+    constructor(unitsPath: URL, systemPath: URL): this(unitsPath.readText(), systemPath.readText())
+
     companion object {
         val service: UnitService by lazy {
             UnitService(
@@ -42,8 +45,8 @@ class UnitService(unitsPath: URL, systemPath: URL) {
     private val defaultUnitByQuantityAndSystem = mutableMapOf<String, MutableMap<String, TypedUnit>>()
 
     init {
-        loadUnits(unitsPath)
-        loadSystem(systemPath)
+        loadUnits(units)
+        loadSystem(systems)
     }
 
     private fun sanitizeIdentifier(identifier: String): String {
@@ -102,8 +105,7 @@ class UnitService(unitsPath: URL, systemPath: URL) {
         }
     }
 
-    private fun loadUnits(unitsPath: URL) {
-        val units = unitsPath.readText()
+    private fun loadUnits(units: String) {
         val mapper: ObjectMapper = jacksonObjectMapper()
 
         // 1. Syntax Check: Every unit item in `units.json` must have the specified keys
@@ -144,8 +146,7 @@ class UnitService(unitsPath: URL, systemPath: URL) {
         }
     }
 
-    private fun loadSystem(systemPath: URL) {
-        val systems = systemPath.readText()
+    private fun loadSystem(systems: String) {
         val mapper: ObjectMapper = jacksonObjectMapper()
         val listOfSystems: List<UnitSystem> = mapper.readValue<List<UnitSystem>>(systems)
 

--- a/src/test/kotlin/UnitTest.kt
+++ b/src/test/kotlin/UnitTest.kt
@@ -33,6 +33,14 @@ class UnitTest {
     }
 
     @Test
+    fun useStringConstructor() {
+        val units = UnitService::class.java.getResource("/units.json")!!.readText()
+        val systems = UnitService::class.java.getResource("/unitSystems.json")!!.readText()
+        val unitService = UnitService(units, systems)
+        unitService.getUnitByExternalId("temperature:deg_c")
+    }
+
+    @Test
     fun convertBetweenUnits() {
         val unitService = UnitService.service
         val unitCelsius = unitService.getUnitByExternalId("temperature:deg_c")


### PR DESCRIPTION
Motivation:

In the long term, the direction of the unit catalog (as I've understood it) is to have a catalog per project in Cognite, so that we can adapt to customer needs.

The endpoints to get the catalogs already exist, and we want to use them in our team.

However these endpoint require login credentials, therefore using an URL to read from does not work, instead I suggest reading the data from the endpoint outside the library then calling this library with the data already fetched using the string constructor.

Open to other suggestions!