### PR TITLE
Add unknown unit

### DIFF
--- a/versions/v1/unitSystems.json
+++ b/versions/v1/unitSystems.json
@@ -173,6 +173,10 @@
       {
         "name": "Angle Per Length",
         "unitExternalId": "angle_per_length:rad-per-m"
+      },
+      {
+        "name": "Unknown",
+        "unitExternalId": "unknown:unknown"
       }
     ]
   },

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -10441,5 +10441,21 @@
     },
     "source": "qudt.org",
     "sourceReference": "https://qudt.org/vocab/unit/L-PER-DAY"
+  },
+  {
+    "externalId": "unknown:unknown",
+    "name": "Unknown",
+    "quantity": "Unknown",
+    "longName": "Unknown unit",
+    "aliasNames": [
+      "Unknown"
+    ],
+    "symbol": "",
+    "conversion": {
+      "multiplier": 1.0,
+      "offset": 0.0
+    },
+    "source": null,
+    "sourceReference": null
   }
 ]


### PR DESCRIPTION
This PR enables users to assign "unknown" as a valid unit external ID for physical measurements with unknown units.

Key Benefits:
- By assigning "unknown" instead of null to the unit external ID, it becomes explicit that the measurement lacks a contextual unit due to insufficient information.
- This approach clearly distinguishes between a truly unknown unit and a missing or undefined unit.