### PR TITLE
Fix checkout action on forks

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -22,8 +22,6 @@ jobs:
     steps:
     - name: Checkout current branch
       uses: actions/checkout@v4
-      with:
-        ref: ${{ github.head_ref }}
 
     - name: Run duplicate check test on current branch
       run: |


### PR DESCRIPTION
this used to fail on forks, no need for the parameter there. E.g. https://github.com/cognitedata/units-catalog/pull/99