### PR TITLE
Add  liquid gas ratio units to the unit catalogue

### DIFF
--- a/versions/v1/unitSystems.json
+++ b/versions/v1/unitSystems.json
@@ -201,6 +201,14 @@
       {
         "name": "Areal Density",
         "unitExternalId": "areal_density:kilogm-per-m2"
+      },
+      {
+        "name": "Gas Liquid Ratio",
+        "unitExternalId": "gas_liquid_ratio:sm3-per-sm3"
+      },
+      {
+        "name": "Liquid Gas Ratio",
+        "unitExternalId": "liquid_gas_ratio:sm3-per-sm3"
       }
     ]
   },
@@ -479,6 +487,14 @@
       {
         "name": "Areal Density",
         "unitExternalId": "areal_density:lb-per-ft2"
+      },
+      {
+        "name": "Gas Liquid Ratio",
+        "unitExternalId": "gas_liquid_ratio:sm3-per-sm3"
+      },
+      {
+        "name": "Liquid Gas Ratio",
+        "unitExternalId": "liquid_gas_ratio:sm3-per-sm3"
       }
     ]
   }

--- a/versions/v1/unitSystems.json
+++ b/versions/v1/unitSystems.json
@@ -201,6 +201,14 @@
       {
         "name": "Areal Density",
         "unitExternalId": "areal_density:kilogm-per-m2"
+      },
+      {
+        "name": "Gas to Liquid Ratio",
+        "unitExternalId": "gas_to_liquid_ratio:scf-per-stb"
+      },
+      {
+        "name": "Liquid to Gas Ratio",
+        "unitExternalId": "liquid_to_gas_ratio:stb-per-mmscf"
       }
     ]
   },
@@ -479,6 +487,14 @@
       {
         "name": "Areal Density",
         "unitExternalId": "areal_density:lb-per-ft2"
+      },
+      {
+        "name": "Gas to Liquid Ratio",
+        "unitExternalId": "gas_to_liquid_ratio:scf-per-stb"
+      },
+      {
+        "name": "Liquid to Gas Ratio",
+        "unitExternalId": "liquid_to_gas_ratio:stb-per-mmscf"
       }
     ]
   }

--- a/versions/v1/unitSystems.json
+++ b/versions/v1/unitSystems.json
@@ -201,14 +201,6 @@
       {
         "name": "Areal Density",
         "unitExternalId": "areal_density:kilogm-per-m2"
-      },
-      {
-        "name": "Gas to Liquid Ratio",
-        "unitExternalId": "gas_to_liquid_ratio:scf-per-stb"
-      },
-      {
-        "name": "Liquid to Gas Ratio",
-        "unitExternalId": "liquid_to_gas_ratio:stb-per-mmscf"
       }
     ]
   },
@@ -487,14 +479,6 @@
       {
         "name": "Areal Density",
         "unitExternalId": "areal_density:lb-per-ft2"
-      },
-      {
-        "name": "Gas to Liquid Ratio",
-        "unitExternalId": "gas_to_liquid_ratio:scf-per-stb"
-      },
-      {
-        "name": "Liquid to Gas Ratio",
-        "unitExternalId": "liquid_to_gas_ratio:stb-per-mmscf"
       }
     ]
   }

--- a/versions/v1/unitSystems.json
+++ b/versions/v1/unitSystems.json
@@ -487,14 +487,6 @@
       {
         "name": "Areal Density",
         "unitExternalId": "areal_density:lb-per-ft2"
-      },
-      {
-        "name": "Gas Liquid Ratio",
-        "unitExternalId": "gas_liquid_ratio:sm3-per-sm3"
-      },
-      {
-        "name": "Liquid Gas Ratio",
-        "unitExternalId": "liquid_gas_ratio:sm3-per-sm3"
       }
     ]
   }

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -11119,8 +11119,8 @@
       "multiplier": 0.178108,
       "offset": 0.0
     },
-    "source": "api.org",
-    "sourceReference": "https://www.api.org/"
+    "source": "petrobasics.com",
+    "sourceReference": "https://www.petrobasics.com/25078/scfstb"
   },
   {
     "externalId": "volume_fraction:stb-per-mmscf",
@@ -11138,7 +11138,7 @@
       "multiplier": 0.000005614583333,
       "offset": 0.0
     },
-    "source": "api.org",
-    "sourceReference": "https://www.api.org/"
+    "source": "petrobasics.com",
+    "sourceReference": "https://www.petrobasics.com/25101/stbmmscf"
   }
 ]

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -11132,7 +11132,7 @@
     ],
     "symbol": "STB/MMscf",
     "conversion": {
-      "multiplier": 1.0,
+      "multiplier": 0.000005614583333,
       "offset": 0.0
     },
     "source": "api.org",

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -11112,7 +11112,7 @@
     "aliasNames": [
       "scf/STB",
       "SCF/STB",
-      "Standard Cubic Feet per Barrel",
+      "Standard Cubic Feet per Barrel"
     ],
     "symbol": "scf/STB",
     "conversion": {

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -11080,5 +11080,62 @@
     },
     "source": "Custom based on qudt.org - https://qudt.org/vocab/unit/LB-PER-FT2",
     "sourceReference": null
+  },
+  {
+    "externalId": "length:1-64-in",
+    "name": "1/64 in",
+    "quantity": "Length",
+    "longName": "One Sixty-Fourth of an Inch",
+    "aliasNames": [
+      "1/64 in",
+      "1/64″",
+      "one sixty-fourth inch",
+      "1-64 inch",
+      "1-64 in"
+    ],
+    "symbol": "¹⁄₆₄″",
+    "conversion": {
+      "multiplier": 0.000396875,
+      "offset": 0.0
+    },
+    "source": "qudt.org",
+    "sourceReference": "https://qudt.org/vocab/unit/IN"
+  },
+  {
+    "externalId": "dimensionless_ratio:scf-per-STB",
+    "name": "scf/STB",
+    "quantity": "Gas to Liquid Ratio",
+    "longName": "Standard Cubic Feet per Stock Tank Barrel",
+    "aliasNames": [
+      "scf/STB",
+      "SCF/STB",
+      "Standard Cubic Feet per Barrel",
+      "GOR"
+    ],
+    "symbol": "scf/STB",
+    "conversion": {
+      "multiplier": 1.0,
+      "offset": 0.0
+    },
+    "source": "api.org",
+    "sourceReference": "https://www.api.org/"
+  },
+  {
+    "externalId": "dimensionless_ratio:STB-per-MMscf",
+    "name": "STB/MMscf",
+    "quantity": "Liquid to Gas Ratio",
+    "longName": "Stock Tank Barrel per Million Standard Cubic Feet",
+    "aliasNames": [
+      "STB/MMscf",
+      "Stock Tank Barrel per MMscf",
+      "CGR"
+    ],
+    "symbol": "STB/MMscf",
+    "conversion": {
+      "multiplier": 1.0,
+      "offset": 0.0
+    },
+    "source": "api.org",
+    "sourceReference": "https://www.api.org/"
   }
 ]

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -11114,7 +11114,7 @@
     ],
     "symbol": "scf/STB",
     "conversion": {
-      "multiplier": 1.0,
+      "multiplier": 0.178108,
       "offset": 0.0
     },
     "source": "api.org",

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -11082,7 +11082,7 @@
     "sourceReference": null
   },
   {
-    "externalId": "length:1-64-in",
+    "externalId": "length:1_64_in",
     "name": "1/64 in",
     "quantity": "Length",
     "longName": "One Sixty-Fourth of an Inch",
@@ -11098,12 +11098,12 @@
       "multiplier": 0.000396875,
       "offset": 0.0
     },
-    "source": "qudt.org",
-    "sourceReference": "https://qudt.org/vocab/unit/IN"
+    "source": "Custom based on qudt.org - https://qudt.org/vocab/unit/IN",
+    "sourceReference": null
   },
   {
-    "externalId": "dimensionless_ratio:scf-per-STB",
-    "name": "scf/STB",
+    "externalId": "gas_to_liquid_ratio:scf-per-stb",
+    "name": "scf-per-STB",
     "quantity": "Gas to Liquid Ratio",
     "longName": "Standard Cubic Feet per Stock Tank Barrel",
     "aliasNames": [
@@ -11121,8 +11121,8 @@
     "sourceReference": "https://www.api.org/"
   },
   {
-    "externalId": "dimensionless_ratio:STB-per-MMscf",
-    "name": "STB/MMscf",
+    "externalId": "liquid_to_gas_ratio:stb-per-mmscf",
+    "name": "STB-per-MMscf",
     "quantity": "Liquid to Gas Ratio",
     "longName": "Stock Tank Barrel per Million Standard Cubic Feet",
     "aliasNames": [

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -11102,7 +11102,7 @@
     "sourceReference": null
   },
   {
-    "externalId": "gas_to_liquid_ratio:scf-per-stb",
+    "externalId": "volume_fraction:scf-per-stb",
     "name": "scf-per-STB",
     "quantity": "Gas to Liquid Ratio",
     "longName": "Standard Cubic Feet per Stock Tank Barrel",

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -10992,7 +10992,7 @@
     },
     "source": "qudt.org",
     "sourceReference": "https://qudt.org/vocab/unit/KiloGM-PER-M2"
-  },
+  }, 
   {
     "externalId": "magnetic_field:gauss",
     "name": "GAUSS",
@@ -11115,8 +11115,8 @@
       "multiplier": 1.0,
       "offset": 0.0
     },
-    "source": "qudt.org",
-    "sourceReference": "https://qudt.org/vocab/unit/M3-PER-M3"
+    "source": "Custom based on qudt.org - https://qudt.org/vocab/unit/M3-PER-M3",
+    "sourceReference": null
   },
   {
     "externalId": "gas_liquid_ratio:scf-per-stb",
@@ -11147,8 +11147,8 @@
       "multiplier": 1.0,
       "offset": 0.0
     },
-    "source": "qudt.org",
-    "sourceReference": "https://qudt.org/vocab/unit/M3-PER-M3"
+    "source": "Custom based on qudt.org - https://qudt.org/vocab/unit/M3-PER-M3",
+    "sourceReference": null
   },
   {
     "externalId": "liquid_gas_ratio:stb-per-mmscf",

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -11091,7 +11091,10 @@
       "1/64″",
       "one sixty-fourth inch",
       "1-64 inch",
-      "1-64 in"
+      "1-64 in",
+      "1/64th in",
+      "1/64th inch",
+      "sixty-fourth inch"
     ],
     "symbol": "¹⁄₆₄″",
     "conversion": {

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -11121,7 +11121,7 @@
     "sourceReference": "https://www.api.org/"
   },
   {
-    "externalId": "liquid_to_gas_ratio:stb-per-mmscf",
+    "externalId": "volume_fraction:stb-per-mmscf",
     "name": "STB-per-MMscf",
     "quantity": "Liquid to Gas Ratio",
     "longName": "Stock Tank Barrel per Million Standard Cubic Feet",

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -11113,8 +11113,6 @@
       "scf/STB",
       "SCF/STB",
       "Standard Cubic Feet per Barrel",
-      "GOR",
-      "GLR"
     ],
     "symbol": "scf/STB",
     "conversion": {

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -10895,7 +10895,7 @@
     "quantity": "Torque",
     "longName": "Kilo Newton Meter",
     "aliasNames": [
-      "KN.M",
+      "KN.M", 
       "KN.m",
       "kilo newton meter"
     ],
@@ -10913,7 +10913,7 @@
     "quantity": "Radioactivity",
     "longName": "Becquerel",
     "aliasNames": [
-      "Bq",
+      "Bq", 
       "BQ"
     ],
     "symbol": "Bq",
@@ -10930,7 +10930,7 @@
     "quantity": "Radioactivity",
     "longName": "Curie",
     "aliasNames": [
-      "Ci",
+      "Ci", 
       "CI"
     ],
     "symbol": "Ci",
@@ -10999,7 +10999,7 @@
     "quantity": "Magnetic Field",
     "longName": "Gauss",
     "aliasNames": [
-      "gauss",
+      "gauss", 
       "Gauss",
       "G",
       "g"
@@ -11018,7 +11018,7 @@
     "quantity": "Magnetic Field",
     "longName": "Nano Tesla",
     "aliasNames": [
-      "NT",
+      "NT", 
       "nT"
     ],
     "symbol": "nT",
@@ -11035,7 +11035,7 @@
     "quantity": "Resistivity",
     "longName": "Ohm Foot",
     "aliasNames": [
-      "OhmFt",
+      "OhmFt", 
       "Ω·ft"
     ],
     "symbol": "Ω·ft",
@@ -11052,7 +11052,7 @@
     "quantity": "Resistivity",
     "longName": "Ohm Meter",
     "aliasNames": [
-      "OhmM",
+      "OhmM", 
       "Ω·m",
       "OHM.M"
     ],
@@ -11105,9 +11105,23 @@
     "sourceReference": null
   },
   {
-    "externalId": "volume_fraction:scf-per-stb",
+    "externalId": "gas_liquid_ratio:sm3-per-sm3",
+    "name": "Sm3-per-Sm3",
+    "quantity": "Gas Liquid Ratio",
+    "longName": "Standard Cubic Meter (@15°C/101.325 kPa) per Standard Cubic Meter (@15°C/101.325 kPa)",
+    "aliasNames": [ "Sm3/Sm3" ],
+    "symbol": "Sm³/Sm³",
+    "conversion": {
+      "multiplier": 1.0,
+      "offset": 0.0
+    },
+    "source": "qudt.org",
+    "sourceReference": "https://qudt.org/vocab/unit/M3-PER-M3"
+  },
+  {
+    "externalId": "gas_liquid_ratio:scf-per-stb",
     "name": "scf-per-STB",
-    "quantity": "Volume Fraction",
+    "quantity": "Gas Liquid Ratio",
     "longName": "Standard Cubic Feet per Stock Tank Barrel",
     "aliasNames": [
       "scf/STB",
@@ -11119,13 +11133,27 @@
       "multiplier": 0.178108,
       "offset": 0.0
     },
-    "source": "petrobasics.com",
-    "sourceReference": "https://www.petrobasics.com/25078/scfstb"
+    "source": "Derived from base unit definitions in qudt.org (1 ft³ = 0.028316846592 m³; 1 bbl = 0.1589873 m³) and assumed standard conditions(scf @60°F/14.73 psia; STB @60°F/14.7 psia; Sm³ @15°C/101.325 kPa). Converts the ratio to the dimensionless SI base Sm³/Sm³.",
+    "sourceReference": "null"
   },
   {
-    "externalId": "volume_fraction:stb-per-mmscf",
+    "externalId": "liquid_gas_ratio:sm3-per-sm3",
+    "name": "Sm3-per-Sm3",
+    "quantity": "Liquid Gas Ratio",
+    "longName": "Standard Cubic Meter (@15°C, 101.325 kPa) per Standard Cubic Meter (@15°C, 101.325 kPa)",
+    "aliasNames": [ "Sm3/Sm3" ],
+    "symbol": "Sm³/Sm³",
+    "conversion": {
+      "multiplier": 1.0,
+      "offset": 0.0
+    },
+    "source": "qudt.org",
+    "sourceReference": "https://qudt.org/vocab/unit/M3-PER-M3"
+  },
+  {
+    "externalId": "liquid_gas_ratio:stb-per-mmscf",
     "name": "STB-per-MMscf",
-    "quantity": "Volume Fraction",
+    "quantity": "Liquid Gas Ratio",
     "longName": "Stock Tank Barrel per Million Standard Cubic Feet",
     "aliasNames": [
       "STB/MMscf",
@@ -11138,7 +11166,7 @@
       "multiplier": 0.000005614583333,
       "offset": 0.0
     },
-    "source": "petrobasics.com",
-    "sourceReference": "https://www.petrobasics.com/25101/stbmmscf"
+    "source": "Derived from base unit definitions in qudt.org (1 ft³ = 0.028316846592 m³; 1 bbl = 0.1589873 m³) and assumed standard conditions (scf @60°F/14.73 psia; STB @60°F/14.7 psia; Sm³ @15°C/101.325 kPa). Converts the ratio to the dimensionless SI base Sm³/Sm³.",
+    "sourceReference": null
   }
 ]

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -11104,13 +11104,14 @@
   {
     "externalId": "volume_fraction:scf-per-stb",
     "name": "scf-per-STB",
-    "quantity": "Gas to Liquid Ratio",
+    "quantity": "Volume Fraction",
     "longName": "Standard Cubic Feet per Stock Tank Barrel",
     "aliasNames": [
       "scf/STB",
       "SCF/STB",
       "Standard Cubic Feet per Barrel",
-      "GOR"
+      "GOR",
+      "GLR"
     ],
     "symbol": "scf/STB",
     "conversion": {
@@ -11123,12 +11124,13 @@
   {
     "externalId": "volume_fraction:stb-per-mmscf",
     "name": "STB-per-MMscf",
-    "quantity": "Liquid to Gas Ratio",
+    "quantity": "Volume Fraction",
     "longName": "Stock Tank Barrel per Million Standard Cubic Feet",
     "aliasNames": [
       "STB/MMscf",
       "Stock Tank Barrel per MMscf",
-      "CGR"
+      "CGR",
+      "WGR"
     ],
     "symbol": "STB/MMscf",
     "conversion": {


### PR DESCRIPTION
**Change**
- Add "STB-per-MMscf" unit
- Add "scf-per-STB" unit
- Add "Sm3-per-Sm3" unit
- Add "Gas Liquid Ratio" quantity
- Add "Liquid Gas Ratio" quantity