### PR TITLE
Add aliases for common AC/DC electrical units: AAC, ADC, VAC, VDC (with kilo and milli versions)

### DIFF
--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -2180,7 +2180,9 @@
       "ampere",
       "A",
       "Amps",
-      "amps"
+      "amps",
+      "AAC",
+      "ADC"
     ],
     "symbol": "A",
     "conversion": {
@@ -2198,7 +2200,9 @@
     "aliasNames": [
       "kiloampere",
       "KiloA",
-      "kA"
+      "kA",
+      "kAAC",
+      "kADC"
     ],
     "symbol": "kA",
     "conversion": {
@@ -2236,7 +2240,9 @@
       "mA",
       "MilliAmpere",
       "milliampere",
-      "MilliA"
+      "MilliA",
+      "mAAC",
+      "mADC"
     ],
     "symbol": "mA",
     "conversion": {
@@ -2255,7 +2261,9 @@
       "Kilovolt",
       "KiloV",
       "kilovolt",
-      "kV"
+      "kV",
+      "kVAC",
+      "kVDC"
     ],
     "symbol": "kV",
     "conversion": {
@@ -2312,7 +2320,9 @@
       "mV",
       "millivolt",
       "Millivolt",
-      "MilliV"
+      "MilliV",
+      "mVAC",
+      "mVDC"
     ],
     "symbol": "mV",
     "conversion": {


### PR DESCRIPTION
This PR proposes adding commonly used electrical unit aliases to the Cognite Units Catalog under the ampere and volt base units. These aliases are widely used in engineering, electrical, and industrial domains to indicate whether the quantity is AC (alternating current) or DC (direct current), and in the case of voltage, to specify higher voltages in kilovolts.

**Proposed Aliases are below:**

**Electric_Current**
- AAC
- ADC
- mAAC
- mADC

**Electric_Potential**
- mVAC
- mVDC
- kVAC
- kVDC

 
**Justification:**
These abbreviations are widely used in electrical datasheets, instrumentation systems, and field equipment documentation.
 
 