### PR TITLE
chore: release to central repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,10 @@ jobs:
       with: # running setup-java again overwrites the settings.xml
         distribution: "temurin"
         java-version: "17"
-        server-id: ossrh
+        server-id: central
         server-username: MAVEN_USERNAME
         server-password: MAVEN_CENTRAL_TOKEN
-        gpg-private-key: ${{ secrets.SONATYPE_OSSRH_GPG_PRIVATE_KEY }}
+        gpg-private-key: ${{ secrets.SONATYPE_CENTRAL_PORTAL_GPG_PRIVATE_KEY }}
         gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
     - name: Install jq

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,6 @@ jobs:
       run: |
         mvn -B clean deploy -P release
       env:
-        MAVEN_USERNAME: ${{ secrets.SONATYPE_OSSRH_USER }}
-        MAVEN_CENTRAL_TOKEN: ${{ secrets.SONATYPE_OSSRH_PASSWORD }}
-        MAVEN_GPG_PASSPHRASE: ${{ secrets.SONATYPE_OSSRH_GPG_KEY_PASSPHRASE }}
+        MAVEN_USERNAME: ${{ secrets.SONATYPE_CENTRAL_PORTAL_USER }}
+        MAVEN_CENTRAL_TOKEN: ${{ secrets.SONATYPE_CENTRAL_PORTAL_PASSWORD }}
+        MAVEN_GPG_PASSPHRASE: ${{ secrets.SONATYPE_CENTRAL_PORTAL_GPG_KEY_PASSPHRASE }}

--- a/pom.xml
+++ b/pom.xml
@@ -227,12 +227,12 @@
       <id>release</id>
       <distributionManagement>
         <snapshotRepository>
-          <id>ossrh</id>
-          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+          <id>central</id>
+          <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </snapshotRepository>
         <repository>
-          <id>ossrh</id>
-          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+          <id>central</id>
+          <url>https://central.sonatype.com/</url>
         </repository>
       </distributionManagement>
       <build>

--- a/pom.xml
+++ b/pom.xml
@@ -41,10 +41,10 @@
   <properties>
     <kotlin.version>1.9.25</kotlin.version>
     <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
-    <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
     <maven-dokka-plugin.version>1.9.20</maven-dokka-plugin.version>
     <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
     <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
+    <central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
     <!-- For reproducible builds -->
     <project.build.outputTimestamp>2020-01-01T01:01:00Z</project.build.outputTimestamp>
   </properties>
@@ -266,17 +266,14 @@
               </execution>
             </executions>
           </plugin>
-          <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>${nexus-staging-maven-plugin.version}</version>
-            <extensions>true</extensions>
-            <configuration>
-              <serverId>central</serverId>
-              <nexusUrl>https://central.sonatype.com/</nexusUrl>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
-              <stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
-            </configuration>
+           <plugin>
+              <groupId>org.sonatype.central</groupId>
+              <artifactId>central-publishing-maven-plugin</artifactId>
+              <version>${central-publishing-maven-plugin.version}</version>
+              <extensions>true</extensions>
+              <configuration>
+                  <publishingServerId>central</publishingServerId>
+              </configuration>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -272,8 +272,8 @@
             <version>${nexus-staging-maven-plugin.version}</version>
             <extensions>true</extensions>
             <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <serverId>central</serverId>
+              <nexusUrl>https://central.sonatype.com/</nexusUrl>
               <autoReleaseAfterClose>true</autoReleaseAfterClose>
               <stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
             </configuration>


### PR DESCRIPTION
> As of June 30, the Open Source Software Repository Hosting (OSSRH) provided by Sonatype has reached end of life and has been shut down. Ref.: https://central.sonatype.org/pages/ossrh-eol/.
> CI/CD workflows that published to OSSRH need to be migrated to [Maven Central Portal](https://central.sonatype.com/).

This PR updates the credential references being used to authenticate to the new repositories and also updates the target URLs where the package will be deployed to.