### PR TITLE
chore: disable manual publish step for maven release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,7 @@
               <extensions>true</extensions>
               <configuration>
                   <publishingServerId>central</publishingServerId>
+                  <autoPublish>true</autoPublish>
               </configuration>
           </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,7 @@
               <configuration>
                   <publishingServerId>central</publishingServerId>
                   <autoPublish>true</autoPublish>
+                  <deploymentName>${project.groupId}:${project.artifactId}:${project.version}</deploymentName>
               </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
Changes:

1. Enable automatic publish

Otherwise we get this message:

```
 Uploaded bundle successfully, deployment name: Deployment, deploymentId: .... Deployment will require manual publishing 
```

We would like to have it automatic, same it was before the migration to maven central.

2. Fix the deployment name on the Sonatype portal

Currenty it shows as just "Deployment", this renames it to something more specific