### PR TITLE
Add non-spaced aliases for g/cm³

### DIFF
--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -1221,6 +1221,7 @@
       "GM per cm³",
       "GM / Cubic centimeter",
       "g / CM3",
+      "g / cm3",
       "g per cubic centimeter",
       "gram / Cubic centimeter",
       "GM / CM3",
@@ -1242,7 +1243,9 @@
       "GM per Cubic Centimeter",
       "Gram Per Cubic Centimeter",
       "Gram / CM3",
-      "Gram / cm³"
+      "Gram / cm³",
+      "g/cm^3",
+      "g/cm3"
     ],
     "symbol": "g/cm³",
     "conversion": {


### PR DESCRIPTION
This adds a few more aliases for g/cm³ encountered in the wild (from drilling and wells). In addition to a lower case version, it also adds aliases where spaces have been stripped out. This resembles the aliases for the matching SI unit kg/m³.