### PR TITLE
Fix: Standardize longName fields to proper title case

### DIFF
--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -51,7 +51,7 @@
     "externalId": "acceleration:in-per-sec2",
     "name": "IN-PER-SEC2",
     "quantity": "Acceleration",
-    "longName": "Inch per Square second",
+    "longName": "Inch per Square Second",
     "aliasNames": [
       "in per square second",
       "Inch / SEC2",
@@ -234,7 +234,7 @@
     "externalId": "amount_of_substance:mol",
     "name": "MOL",
     "quantity": "Amount Of Substance",
-    "longName": "mole",
+    "longName": "Mole",
     "aliasNames": [
       "MOL",
       "mol",
@@ -252,7 +252,7 @@
     "externalId": "amount_of_substance_per_unit_volume:centimol-per-l",
     "name": "CentiMOL-PER-L",
     "quantity": "Amount Of Substance Per Unit Volume",
-    "longName": "Centimole per litre",
+    "longName": "Centimole per Litre",
     "aliasNames": [
       "CentiMOL / liter",
       "CentiMole per Liter",
@@ -367,7 +367,7 @@
     "externalId": "amount_of_substance_per_unit_volume:micromol-per-l",
     "name": "MicroMOL-PER-L",
     "quantity": "Amount Of Substance Per Unit Volume",
-    "longName": "Micromoles per litre",
+    "longName": "Micromoles per Litre",
     "aliasNames": [
       "μmol per litre",
       "micromole per liter",
@@ -425,7 +425,7 @@
     "externalId": "amount_of_substance_per_unit_volume:millimol-per-l",
     "name": "MilliMOL-PER-L",
     "quantity": "Amount Of Substance Per Unit Volume",
-    "longName": "millimoles per litre",
+    "longName": "Millimoles per Litre",
     "aliasNames": [
       "Millimole per Liter",
       "mmol per liter",
@@ -482,7 +482,7 @@
     "externalId": "amount_of_substance_per_unit_volume:millimol-per-m3",
     "name": "MilliMOL-PER-M3",
     "quantity": "Amount Of Substance Per Unit Volume",
-    "longName": "Millimoles per cubic metre",
+    "longName": "Millimoles per Cubic Metre",
     "aliasNames": [
       "millimole per Cubic Meter",
       "Millimole / Cubic Meter",
@@ -728,7 +728,7 @@
     "externalId": "angle:microrad",
     "name": "MicroRAD",
     "quantity": "Angle",
-    "longName": "microradian",
+    "longName": "Microradian",
     "aliasNames": [
       "microradian",
       "MicroRAD",
@@ -746,7 +746,7 @@
     "externalId": "angle:millirad",
     "name": "MilliRAD",
     "quantity": "Angle",
-    "longName": "milliradian",
+    "longName": "Milliradian",
     "aliasNames": [
       "milliradian",
       "MilliRAD",
@@ -764,7 +764,7 @@
     "externalId": "angle:rad",
     "name": "RAD",
     "quantity": "Angle",
-    "longName": "radian",
+    "longName": "Radian",
     "aliasNames": [
       "rad",
       "radian",
@@ -1152,7 +1152,7 @@
     "externalId": "capacitance:farad",
     "name": "FARAD",
     "quantity": "Capacitance",
-    "longName": "farad",
+    "longName": "Farad",
     "aliasNames": [
       "FARAD",
       "farad",
@@ -1170,7 +1170,7 @@
     "externalId": "capacitance:microfarad",
     "name": "MicroFARAD",
     "quantity": "Capacitance",
-    "longName": "microfarad",
+    "longName": "Microfarad",
     "aliasNames": [
       "microfarad",
       "MicroFARAD",
@@ -1318,7 +1318,7 @@
     "externalId": "density:kilogm-per-m3",
     "name": "KiloGM-PER-M3",
     "quantity": "Density",
-    "longName": "kilogram per cubic meter",
+    "longName": "Kilogram per Cubic Meter",
     "aliasNames": [
       "kilogram / Cubic Meter",
       "KiloGM / Cubic Meter",
@@ -1365,7 +1365,7 @@
     "externalId": "density:kilogm-per-l",
     "name": "KiloGM-PER-L",
     "quantity": "Density",
-    "longName": "kilogram per litre",
+    "longName": "Kilogram per Litre",
     "aliasNames": [
       "kilogram / Litre",
       "kg/l",
@@ -1751,7 +1751,7 @@
     "externalId": "dimensionless_ratio:ppb",
     "name": "PPB",
     "quantity": "Dimensionless Ratio",
-    "longName": "Parts per billion",
+    "longName": "Parts per Billion",
     "aliasNames": [
       "PPB",
       "ppb",
@@ -1770,7 +1770,7 @@
     "externalId": "dimensionless_ratio:ppm",
     "name": "PPM",
     "quantity": "Dimensionless Ratio",
-    "longName": "Parts per million",
+    "longName": "Parts per Million",
     "aliasNames": [
       "PPM",
       "Parts per million",
@@ -1789,7 +1789,7 @@
     "externalId": "dimensionless_ratio:ppth",
     "name": "PPTH",
     "quantity": "Dimensionless Ratio",
-    "longName": "Parts per thousand",
+    "longName": "Parts per Thousand",
     "aliasNames": [
       "PPTH",
       "‰",
@@ -2137,7 +2137,7 @@
     "externalId": "dynamic_viscosity:pa-sec",
     "name": "PA-SEC",
     "quantity": "Dynamic Viscosity",
-    "longName": "pascal second",
+    "longName": "Pascal Second",
     "aliasNames": [
       "pascal SEC",
       "PA second",
@@ -2181,7 +2181,7 @@
     "externalId": "electric_current:a",
     "name": "A",
     "quantity": "Electric Current",
-    "longName": "ampere",
+    "longName": "Ampere",
     "aliasNames": [
       "ampere",
       "A",
@@ -2203,7 +2203,7 @@
     "externalId": "electric_current:kiloa",
     "name": "KiloA",
     "quantity": "Electric Current",
-    "longName": "kiloampere",
+    "longName": "Kiloampere",
     "aliasNames": [
       "kiloampere",
       "KiloA",
@@ -2454,7 +2454,7 @@
     "externalId": "electric_potential:v",
     "name": "V",
     "quantity": "Electric Potential",
-    "longName": "volt",
+    "longName": "Volt",
     "aliasNames": [
       "V",
       "volt",
@@ -2517,7 +2517,7 @@
     "externalId": "energy:cal_it",
     "name": "CAL_IT",
     "quantity": "Energy",
-    "longName": "International Table calorie",
+    "longName": "International Table Calorie",
     "aliasNames": [
       "International Table calorie",
       "international table calorie",
@@ -2639,7 +2639,7 @@
     "externalId": "energy:j",
     "name": "J",
     "quantity": "Energy",
-    "longName": "joule",
+    "longName": "Joule",
     "aliasNames": [
       "J",
       "joule"
@@ -3341,7 +3341,7 @@
     "externalId": "energy_density:w-hr-per-m3",
     "name": "W-HR-PER-M3",
     "quantity": "Energy Density",
-    "longName": "Watthour per Cubic meter",
+    "longName": "Watthour per Cubic Meter",
     "aliasNames": [
       "W ⋅ hr / m³",
       "watt Hour per cubic metre",
@@ -3500,7 +3500,7 @@
     "externalId": "force:kilodan",
     "name": "KiloDaN",
     "quantity": "Force",
-    "longName": "Kilo decanewton",
+    "longName": "Kilo Decanewton",
     "aliasNames": [
       "KDAN",
       "KiloDecN",
@@ -3590,7 +3590,7 @@
     "externalId": "force:n",
     "name": "N",
     "quantity": "Force",
-    "longName": "newton",
+    "longName": "Newton",
     "aliasNames": [
       "newton",
       "N"
@@ -3626,7 +3626,7 @@
     "externalId": "frequency:hz",
     "name": "HZ",
     "quantity": "Frequency",
-    "longName": "hertz",
+    "longName": "Hertz",
     "aliasNames": [
       "Hz",
       "HZ",
@@ -3664,7 +3664,7 @@
     "externalId": "frequency:num-per-hr",
     "name": "NUM-PER-HR",
     "quantity": "Frequency",
-    "longName": "Number per hour",
+    "longName": "Number per Hour",
     "aliasNames": [
       "Number / Hour",
       "number per hr",
@@ -3715,7 +3715,7 @@
     "externalId": "frequency:num-per-sec",
     "name": "NUM-PER-SEC",
     "quantity": "Frequency",
-    "longName": "Counts per second",
+    "longName": "Counts per Second",
     "aliasNames": [
       "Number per second",
       "# / s",
@@ -3829,7 +3829,7 @@
     "externalId": "inductance:h",
     "name": "H",
     "quantity": "Inductance",
-    "longName": "henry",
+    "longName": "Henry",
     "aliasNames": [
       "H",
       "henry"
@@ -4178,7 +4178,7 @@
     "externalId": "mass:kilogm",
     "name": "KiloGM",
     "quantity": "Mass",
-    "longName": "kilogram",
+    "longName": "Kilogram",
     "aliasNames": [
       "kg",
       "kilogram",
@@ -4311,7 +4311,7 @@
     "externalId": "mass_concentration:kilogm-per-m3",
     "name": "KiloGM-PER-M3",
     "quantity": "Mass Concentration",
-    "longName": "kilogram per cubic meter",
+    "longName": "Kilogram per Cubic Meter",
     "aliasNames": [
       "kilogram / Cubic Meter",
       "KiloGM / Cubic Meter",
@@ -6020,7 +6020,7 @@
     "externalId": "power:w",
     "name": "W",
     "quantity": "Power",
-    "longName": "watt",
+    "longName": "Watt",
     "aliasNames": [
       "watt",
       "W"
@@ -6165,7 +6165,7 @@
     "externalId": "pressure:kilogm-per-m-sec2",
     "name": "KiloGM-PER-M-SEC2",
     "quantity": "Pressure",
-    "longName": "Kilograms per meter per square second",
+    "longName": "Kilograms per Meter per Square Second",
     "aliasNames": [
       "KiloGM per metre SEC2",
       "KiloGM per M SEC2",
@@ -6779,7 +6779,7 @@
     "externalId": "pressure:pa",
     "name": "PA",
     "quantity": "Pressure",
-    "longName": "pascal",
+    "longName": "Pascal",
     "aliasNames": [
       "pascal",
       "PA",
@@ -6840,7 +6840,7 @@
     "externalId": "pressure_gradient:pa-per-m",
     "name": "PA-PER-M",
     "quantity": "Pressure Gradient",
-    "longName": "Pascal per meter",
+    "longName": "Pascal per Meter",
     "aliasNames": [
       "pascal per metre",
       "Pascal per metre",
@@ -6862,7 +6862,7 @@
     "externalId": "pressure_gradient:bar-per-m",
     "name": "BAR-PER-M",
     "quantity": "Pressure Gradient",
-    "longName": "Bar per meter",
+    "longName": "Bar per Meter",
     "aliasNames": [
       "bar per metre",
       "Bar per metre",
@@ -6883,7 +6883,7 @@
     "externalId": "pressure_gradient:kilopa-per-m",
     "name": "KiloPA-PER-M",
     "quantity": "Pressure Gradient",
-    "longName": "Kilopascal per meter",
+    "longName": "Kilopascal per Meter",
     "aliasNames": [
       "kilopascal per metre",
       "kiloPascal per metre",
@@ -7040,7 +7040,7 @@
     "externalId": "resistance:ohm",
     "name": "OHM",
     "quantity": "Resistance",
-    "longName": "ohm",
+    "longName": "Ohm",
     "aliasNames": [
       "ohm",
       "Ω",
@@ -7624,7 +7624,7 @@
     "externalId": "surface_tension:w-hr-per-m2",
     "name": "W-HR-PER-M2",
     "quantity": "Surface Tension",
-    "longName": "Watt hour per square meter",
+    "longName": "Watt Hour per Square Meter",
     "aliasNames": [
       "W hour per M2",
       "W Hour / Square Meter",
@@ -7722,7 +7722,7 @@
     "externalId": "surface_tension:w-sec-per-m2",
     "name": "W-SEC-PER-M2",
     "quantity": "Surface Tension",
-    "longName": "Watt seconds per square meter",
+    "longName": "Watt Seconds per Square Meter",
     "aliasNames": [
       "watt SEC / m²",
       "W second per Square Meter",
@@ -7801,7 +7801,7 @@
     "externalId": "temperature:deg_c",
     "name": "DEG_C",
     "quantity": "Temperature",
-    "longName": "degree Celsius",
+    "longName": "Degree Celsius",
     "aliasNames": [
       "DEGC",
       "degC",
@@ -7928,7 +7928,7 @@
     "externalId": "temperature:k",
     "name": "K",
     "quantity": "Temperature",
-    "longName": "kelvin",
+    "longName": "Kelvin",
     "aliasNames": [
       "degree Kelvin",
       "DEG K",
@@ -7969,7 +7969,7 @@
     "externalId": "temperature_gradient:k-per-m",
     "name": "K-PER-M",
     "quantity": "Temperature Gradient",
-    "longName": "Degrees Kelvin per meter",
+    "longName": "Degrees Kelvin per Meter",
     "aliasNames": [
       "kelvin per m",
       "kelvins per metre",
@@ -8055,7 +8055,7 @@
     "externalId": "time:microsec",
     "name": "MicroSEC",
     "quantity": "Time",
-    "longName": "microsecond",
+    "longName": "Microsecond",
     "aliasNames": [
       "microsecond",
       "µs",
@@ -8073,7 +8073,7 @@
     "externalId": "time:millisec",
     "name": "MilliSEC",
     "quantity": "Time",
-    "longName": "millisecond",
+    "longName": "Millisecond",
     "aliasNames": [
       "millisecond",
       "ms",
@@ -8127,7 +8127,7 @@
     "externalId": "time:sec",
     "name": "SEC",
     "quantity": "Time",
-    "longName": "second",
+    "longName": "Second",
     "aliasNames": [
       "second",
       "SEC",
@@ -8977,7 +8977,7 @@
     "externalId": "volume:centim3",
     "name": "CentiM3",
     "quantity": "Volume",
-    "longName": "cubic centimeter",
+    "longName": "Cubic Centimeter",
     "aliasNames": [
       "cubic centimetre",
       "cm³",
@@ -9255,7 +9255,7 @@
     "externalId": "volume:microm3",
     "name": "MicroM3",
     "quantity": "Volume",
-    "longName": "Cubic micrometers (microns)",
+    "longName": "Cubic Micrometers (Microns)",
     "aliasNames": [
       "cubic micrometres (microns)",
       "µm³",
@@ -11145,7 +11145,7 @@
     "externalId": "power_per_area:w-per-m2",
     "name": "W-PER-M2",
     "quantity": "Power Per Area",
-    "longName": "Watt per square meter",
+    "longName": "Watt per Square Meter",
     "aliasNames": [
       "W/m²",
       "W/m2",
@@ -11815,7 +11815,7 @@
     "externalId": "density:milligm-per-l",
     "name": "MilliGM-PER-L",
     "quantity": "Density",
-    "longName": "Milligram per litre",
+    "longName": "Milligram per Litre",
     "aliasNames": [
       "mg/L",
       "milligrams per liter",
@@ -11835,7 +11835,7 @@
     "externalId": "mass_concentration:milligm-per-l",
     "name": "MilliGM-PER-L",
     "quantity": "Mass Concentration",
-    "longName": "Milligram per litre",
+    "longName": "Milligram per Litre",
     "aliasNames": [
       "mg/L",
       "milligrams per liter",


### PR DESCRIPTION
This PR updates all `longName` fields in units.json to use consistent title casing.

**Changes:**
- Capitalize the first word and all significant words
- Keep prepositions (per, of, and) in lowercase
- Updated 51 unit entries

**Example:**
- `degree Celsius` → `Degree Celsius`
- `millimoles per litre` → `Millimoles per Litre`
- `kilogram per cubic meter` → `Kilogram per Cubic Meter`

This improves consistency and readability across the units catalog.