### PR TITLE
Reactive Power: Make use of the correct symbol and not description

### DIFF
--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -6952,7 +6952,7 @@
       "VAR",
       "VAr"
     ],
-    "symbol": "VA{Reactive}",
+    "symbol": "var",
     "conversion": {
       "multiplier": 1.0,
       "offset": 0.0
@@ -6971,7 +6971,7 @@
       "kvar: kilovar",
       "KVAr"
     ],
-    "symbol": "kVA{Reactive}",
+    "symbol": "kvar",
     "conversion": {
       "multiplier": 1000.0,
       "offset": 0.0
@@ -6988,14 +6988,14 @@
       "MVAR",
       "MVAr"
     ],
-    "symbol": "MVA{Reactive}",
+    "symbol": "Mvar",
     "conversion": {
       "multiplier": 1.0e6,
       "offset": 0.0
     },
     "source": "qudt.org",
     "sourceReference": "https://qudt.org/vocab/unit/MegaVAR"
-  },  
+  },
   {
     "externalId": "resistance:kiloohm",
     "name": "KiloOHM",


### PR DESCRIPTION
The proper unit for reactive power is "var" already standardised in 1930 by the EEC (see also https://en.wikipedia.org/wiki/Volt-ampere#Reactive)

The QUDT points kind of to the correct unit but misinterprets the symbol in https://qudt.org/vocab/unit/VAR  from its own source (https://cdd.iec.ch/cdd/iec62720/iec62720.nsf/Units/0112-2---62720%23UAB023)

To emphasis, the equivalent for "Apparent Power" is configured correctly to "VA" from https://qudt.org/vocab/unit/VA and https://cdd.iec.ch/cdd/iec62720/iec62720.nsf/Units/0112-2---62720%23UAA298 , respectively
