### PR TITLE
Add unit aliases (hp, ft/s, lbm/d, STB/d/psi) and new Reservoir Volume Flow Rate quantity

### DIFF
--- a/src/test/kotlin/EquivalentUnits.kt
+++ b/src/test/kotlin/EquivalentUnits.kt
@@ -57,6 +57,8 @@ class EquivalentUnits {
             "volume:m3",
             "volume:microl",
             "volume:millim3",
+            "volume_flow_rate:bbl_us-per-day",
+            "volume_flow_rate:rb-per-day",
             "volume_flow_rate:centim3-per-sec",
             "volume_flow_rate:millil-per-sec",
             "volume_flow_rate:decim3-per-min",

--- a/src/test/kotlin/EquivalentUnits.kt
+++ b/src/test/kotlin/EquivalentUnits.kt
@@ -57,8 +57,6 @@ class EquivalentUnits {
             "volume:m3",
             "volume:microl",
             "volume:millim3",
-            "volume_flow_rate:bbl_us-per-day",
-            "volume_flow_rate:rb-per-day",
             "volume_flow_rate:centim3-per-sec",
             "volume_flow_rate:millil-per-sec",
             "volume_flow_rate:decim3-per-min",

--- a/versions/v1/unitSystems.json
+++ b/versions/v1/unitSystems.json
@@ -225,6 +225,10 @@
       {
         "name": "Volume per time per pressure",
         "unitExternalId": "volume_per_time_per_pressure:m3-per-sec-per-pa"
+      },
+      {
+        "name": "Reservoir Volume Flow Rate",
+        "unitExternalId": "reservoir_volume_flow_rate:rb-per-day"
       }
     ]
   },

--- a/versions/v1/unitSystems.json
+++ b/versions/v1/unitSystems.json
@@ -225,6 +225,10 @@
       {
         "name": "Volume per time per pressure",
         "unitExternalId": "volume_per_time_per_pressure:m3-per-sec-per-pa"
+      },
+      {
+        "name": "Productivity Index",
+        "unitExternalId": "productivity_index:stbday-per-psi"
       }
     ]
   },

--- a/versions/v1/unitSystems.json
+++ b/versions/v1/unitSystems.json
@@ -529,8 +529,8 @@
         "unitExternalId": "volume_per_time_per_pressure:ft3-per-sec-per-psi"
       },
       {
-        "name": "Well Index",
-        "unitExternalId": "well_index:stbday-per-psi"
+        "name": "Productivity Index",
+        "unitExternalId": "productivity_index:stbday-per-psi"
       }
     ]
   }

--- a/versions/v1/unitSystems.json
+++ b/versions/v1/unitSystems.json
@@ -225,10 +225,6 @@
       {
         "name": "Volume per time per pressure",
         "unitExternalId": "volume_per_time_per_pressure:m3-per-sec-per-pa"
-      },
-      {
-        "name": "Productivity Index",
-        "unitExternalId": "productivity_index:stbday-per-psi"
       }
     ]
   },
@@ -531,11 +527,8 @@
       {
         "name": "Volume per time per pressure",
         "unitExternalId": "volume_per_time_per_pressure:ft3-per-sec-per-psi"
-      },
-      {
-        "name": "Productivity Index",
-        "unitExternalId": "productivity_index:stbday-per-psi"
       }
     ]
   }
 ]
+

--- a/versions/v1/unitSystems.json
+++ b/versions/v1/unitSystems.json
@@ -527,6 +527,10 @@
       {
         "name": "Volume per time per pressure",
         "unitExternalId": "volume_per_time_per_pressure:ft3-per-sec-per-psi"
+      },
+      {
+        "name": "Well Index",
+        "unitExternalId": "well_index:stbday-per-psi"
       }
     ]
   }

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -9388,10 +9388,10 @@
     "sourceReference": "https://qudt.org/vocab/unit/BBL_US-PER-DAY"
   },
   {
-    "externalId": "volume_flow_rate:rb-per-day",
+    "externalId": "reservoir_volume_flow_rate:rb-per-day",
     "name": "RB-PER-DAY",
-    "quantity": "Volume Flow Rate",
-    "longName": "Reservoir Barrel Per Day (at Standard Conditions)",
+    "quantity": "Reservoir Volume Flow Rate",
+    "longName": "Reservoir Barrel Per Day",
     "aliasNames": [
       "RB/d",
       "rb/d",
@@ -9403,11 +9403,11 @@
     ],
     "symbol": "RB/d",
     "conversion": {
-      "multiplier": 1.84013e-06,
+      "multiplier": 1.84e-06,
       "offset": 0.0
     },
-    "source": "https://wiki.aapg.org/Fluid_flow_fundamentals",
-    "sourceReference": "Defined at standard surface conditions (60°F, 14.7 psia). At these conditions RB/d is numerically equivalent to STB/d. Conversion factor identical to STB/d (1 barrel = 0.158987 m³, 1 day = 86400 s)."
+    "source": "Custom based on Energistics - https://www.energistics.org/energistics-unit-of-measure-standard",
+    "sourceReference": null
   },
   {
     "externalId": "volume_flow_rate:bbl_us_pet-per-hr",

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -9377,7 +9377,10 @@
       "bbls/day",
       "BBl/d",
       "bbl./d",
-      "BBL/D"
+      "BBL/D",
+      "RB/d",
+      "rb/d",
+      "Reservoir Barrel Per Day"
     ],
     "symbol": "bbl/day",
     "conversion": {
@@ -12252,9 +12255,9 @@
     "sourceReference": null
   },
   {
-    "externalId": "well_index:stbday-per-psi",
+    "externalId": "productivity_index:stbday-per-psi",
     "name": "STBDAY-PER-PSI",
-    "quantity": "Well Index",
+    "quantity": "Productivity Index",
     "longName": "Stock Tank Barrel Per Day Per Psi",
     "aliasNames": [
       "STB/d/psi",
@@ -12272,7 +12275,7 @@
       "multiplier": 2.668884e-10,
       "offset": 0.0
     },
-    "source": "https://www.energistics.org/energistics-unit-of-measure-standard",
+    "source": "https://wiki.aapg.org/Fluid_flow_fundamentals",
     "sourceReference": null
   }
 ]

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -9377,10 +9377,7 @@
       "bbls/day",
       "BBl/d",
       "bbl./d",
-      "BBL/D",
-      "RB/d",
-      "rb/d",
-      "Reservoir Barrel Per Day"
+      "BBL/D"
     ],
     "symbol": "bbl/day",
     "conversion": {
@@ -9389,6 +9386,28 @@
     },
     "source": "qudt.org",
     "sourceReference": "https://qudt.org/vocab/unit/BBL_US-PER-DAY"
+  },
+  {
+    "externalId": "volume_flow_rate:rb-per-day",
+    "name": "RB-PER-DAY",
+    "quantity": "Volume Flow Rate",
+    "longName": "Reservoir Barrel Per Day (at Standard Conditions)",
+    "aliasNames": [
+      "RB/d",
+      "rb/d",
+      "Reservoir Barrel Per Day",
+      "reservoir barrel per day",
+      "RB/D",
+      "RBPD",
+      "rbpd"
+    ],
+    "symbol": "RB/d",
+    "conversion": {
+      "multiplier": 1.84013e-06,
+      "offset": 0.0
+    },
+    "source": "https://wiki.aapg.org/Fluid_flow_fundamentals",
+    "sourceReference": "Defined at standard surface conditions (60°F, 14.7 psia). At these conditions RB/d is numerically equivalent to STB/d. Conversion factor identical to STB/d (1 barrel = 0.158987 m³, 1 day = 86400 s)."
   },
   {
     "externalId": "volume_flow_rate:bbl_us_pet-per-hr",
@@ -12151,7 +12170,8 @@
       "bbl per psi d",
       "bbl/psi/day",
       "barrels per (psi.d)",
-      "bbl per (psi.d)"
+      "bbl per (psi.d)",
+      "STB/d/psi"
     ],
     "symbol": "bbl/(psi.d)",
     "conversion": {
@@ -12252,30 +12272,6 @@
       "offset": 0.0
     },
     "source": "Custom based on Energistics - https://www.energistics.org/energistics-unit-of-measure-standard",
-    "sourceReference": null
-  },
-  {
-    "externalId": "productivity_index:stbday-per-psi",
-    "name": "STBDAY-PER-PSI",
-    "quantity": "Productivity Index",
-    "longName": "Stock Tank Barrel Per Day Per Psi",
-    "aliasNames": [
-      "STB/d/psi",
-      "stb/d/psi",
-      "STB/D/psi",
-      "stbd/psi",
-      "STBD/psi",
-      "STB/day/psi",
-      "stb/day/psi",
-      "STBD/PSI",
-      "stbd/PSI"
-    ],
-    "symbol": "STB/d/psi",
-    "conversion": {
-      "multiplier": 2.668884e-10,
-      "offset": 0.0
-    },
-    "source": "https://wiki.aapg.org/Fluid_flow_fundamentals",
     "sourceReference": null
   }
 ]

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -5545,7 +5545,8 @@
     "aliasNames": [
       "Horsepower",
       "horsepower",
-      "HP"
+      "HP",
+      "hp"
     ],
     "symbol": "HP",
     "conversion": {
@@ -6995,7 +6996,7 @@
     },
     "source": "qudt.org",
     "sourceReference": "https://qudt.org/vocab/unit/MegaVAR"
-  },  
+  },
   {
     "externalId": "resistance:kiloohm",
     "name": "KiloOHM",
@@ -8377,7 +8378,8 @@
       "foot per SEC",
       "FT per second",
       "Foot per Second",
-      "Foot / s"
+      "Foot / s",
+      "ft/s"
     ],
     "symbol": "ft/s",
     "conversion": {
@@ -9375,7 +9377,10 @@
       "bbls/day",
       "BBl/d",
       "bbl./d",
-      "BBL/D"
+      "BBL/D",
+      "RB/d",
+      "rb/d",
+      "Reservoir Barrel Per Day"
     ],
     "symbol": "bbl/day",
     "conversion": {
@@ -12093,7 +12098,8 @@
       "LB/day",
       "lb/Day",
       "LB/Day",
-      "lbm/Day"
+      "lbm/Day",
+      "lbm/d"
     ],
     "symbol": "lbm/d",
     "conversion": {
@@ -12246,6 +12252,26 @@
       "offset": 0.0
     },
     "source": "Custom based on Energistics - https://www.energistics.org/energistics-unit-of-measure-standard",
+    "sourceReference": null
+  },
+  {
+    "externalId": "well_index:stbday-per-psi",
+    "name": "STBDAY-PER-PSI",
+    "quantity": "Well Index",
+    "longName": "Stock Tank Barrel Per Day Per Psi",
+    "aliasNames": [
+      "STB/d/psi",
+      "stb/d/psi",
+      "STB/D/psi",
+      "stbd/psi",
+      "STBD/psi"
+    ],
+    "symbol": "STB/d/psi",
+    "conversion": {
+      "multiplier": 2.668884e-10,
+      "offset": 0.0
+    },
+    "source": "https://www.energistics.org/energistics-unit-of-measure-standard",
     "sourceReference": null
   }
 ]

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -9377,10 +9377,7 @@
       "bbls/day",
       "BBl/d",
       "bbl./d",
-      "BBL/D",
-      "RB/d",
-      "rb/d",
-      "Reservoir Barrel Per Day"
+      "BBL/D"
     ],
     "symbol": "bbl/day",
     "conversion": {
@@ -12264,7 +12261,11 @@
       "stb/d/psi",
       "STB/D/psi",
       "stbd/psi",
-      "STBD/psi"
+      "STBD/psi",
+      "STB/day/psi",
+      "stb/day/psi",
+      "STBD/PSI",
+      "stbd/PSI"
     ],
     "symbol": "STB/d/psi",
     "conversion": {


### PR DESCRIPTION
## Summary

Adds missing case-sensitive aliases to existing units and introduces a new "Reservoir Volume Flow Rate" quantity with the Reservoir Barrel Per Day (RB/d) unit.

### New aliases
- **power:hp** — added lowercase `hp` (case-sensitive match; `HP` did not cover `hp`)
- **velocity:ft-per-sec** — added `ft/s` (the unit's own symbol was not in aliasNames)
- **mass_flow_rate:lb-per-day** — added `lbm/d` (lowercase short form to match the unit's symbol)
- **volume_per_time_per_pressure:bbl_us-per-day-per-psi** — added `STB/d/psi` alias

### New quantity and unit
- **reservoir_volume_flow_rate:rb-per-day** — new "Reservoir Volume Flow Rate" quantity with Reservoir Barrel Per Day (RB/d) as its first unit. This is placed in a dedicated. quantity (rather than under "Volume Flow Rate") because converting between reservoir and surface condition volumes requires the formation volume factor (Bo), which is reservoir-specific. A separate quantity prevents invalid automatic cross-conversions with surface-condition units like STB/d or bbl/d.