### PR TITLE
Update Cognite catalog based on latest QUDT definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Each item in the `units.json` has the following structure:
 - `symbol`: The symbol for the unit (e.g., `°C`).
 - `aliasNames`: An array of possible **aliases** for the unit.
 - `quantity`: Specifies the physical quantity the unit measures (e.g., `Temperature`).
-- `conversion`: An object containing **multiplier** and **offset** values for converting between units. Store at most **12 significant digits**.
+- `conversion`: An object containing **multiplier** and **offset** values for converting between units.
 - `source`: The primary source of the unit (e.g., `qudt.org`).
 - `sourceReference`: A URL reference to the unit definition on an external source, if available. For QUDT units, this must follow the format `https://qudt.org/vocab/unit/{UNIT_NAME}` where UNIT_NAME matches the `name` field.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Each item in the `units.json` has the following structure:
 - `symbol`: The symbol for the unit (e.g., `°C`).
 - `aliasNames`: An array of possible **aliases** for the unit.
 - `quantity`: Specifies the physical quantity the unit measures (e.g., `Temperature`).
-- `conversion`: An object containing **multiplier** and **offset** values for converting between units.
+- `conversion`: An object containing **multiplier** and **offset** values for converting between units. Store at most **12 significant digits**.
 - `source`: The primary source of the unit (e.g., `qudt.org`).
 - `sourceReference`: A URL reference to the unit definition on an external source, if available. For QUDT units, this must follow the format `https://qudt.org/vocab/unit/{UNIT_NAME}` where UNIT_NAME matches the `name` field.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Each item in the `units.json` has the following structure:
 - `symbol`: The symbol for the unit (e.g., `°C`).
 - `aliasNames`: An array of possible **aliases** for the unit.
 - `quantity`: Specifies the physical quantity the unit measures (e.g., `Temperature`).
-- `conversion`: An object containing **multiplier** and **offset** values for converting between units.
+- `conversion`: An object containing **multiplier** and **offset** values for converting between units. Store at most **17 significant digits** following the IEEE 754 double-precision round-trip limit.
 - `source`: The primary source of the unit (e.g., `qudt.org`).
 - `sourceReference`: A URL reference to the unit definition on an external source, if available. For QUDT units, this must follow the format `https://qudt.org/vocab/unit/{UNIT_NAME}` where UNIT_NAME matches the `name` field.
 

--- a/src/test/kotlin/EquivalentUnits.kt
+++ b/src/test/kotlin/EquivalentUnits.kt
@@ -63,6 +63,8 @@ class EquivalentUnits {
             "volume_flow_rate:l-per-min",
             "volume_flow_rate:decim3-per-sec",
             "volume_flow_rate:l-per-sec",
+            "volume_flow_rate:kilol-per-hr",
+            "volume_flow_rate:m3-per-hr",
             "volume_fraction:centim3-per-centim3",
             "volume_fraction:l-per-l",
             "volume_fraction:m3-per-m3",

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -1424,7 +1424,7 @@
     ],
     "symbol": "lbm/ft³",
     "conversion": {
-      "multiplier": 16.018463373960138,
+      "multiplier": 16.018463374,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -1504,7 +1504,7 @@
     ],
     "symbol": "lbm/in³",
     "conversion": {
-      "multiplier": 27679.904710203125,
+      "multiplier": 27679.9047102,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -1555,7 +1555,7 @@
     ],
     "symbol": "lbm/yd³",
     "conversion": {
-      "multiplier": 0.5932764212577829,
+      "multiplier": 0.593276421258,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -1983,7 +1983,7 @@
     ],
     "symbol": "lbm/(ft⋅h)",
     "conversion": {
-      "multiplier": 0.0004133788732137649,
+      "multiplier": 0.000413378873214,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -2098,7 +2098,7 @@
     ],
     "symbol": "lbm/(ft⋅s)",
     "conversion": {
-      "multiplier": 1.4881639435695537,
+      "multiplier": 1.48816394357,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -2282,7 +2282,7 @@
     ],
     "symbol": "A/h",
     "conversion": {
-      "multiplier": 0.0002777777777777778,
+      "multiplier": 0.000277777777778,
       "offset": 0.0
     },
     "source": "Custom based on qudt.org - https://qudt.org/vocab/unit/A and https://qudt.org/vocab/unit/HR",
@@ -2311,7 +2311,7 @@
     ],
     "symbol": "A/min",
     "conversion": {
-      "multiplier": 0.016666666666666666,
+      "multiplier": 0.0166666666667,
       "offset": 0.0
     },
     "source": "Custom based on qudt.org - https://qudt.org/vocab/unit/A and https://qudt.org/vocab/unit/MIN",
@@ -2578,7 +2578,7 @@
     ],
     "symbol": "ft⋅lbf",
     "conversion": {
-      "multiplier": 1.355817948331400399999999999999999,
+      "multiplier": 1.35581794833,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -3234,7 +3234,7 @@
     ],
     "symbol": "Btu{th}/ft³",
     "conversion": {
-      "multiplier": 37234.02819853084296428143745759641,
+      "multiplier": 37234.0281985,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -3470,7 +3470,7 @@
     ],
     "symbol": "klbf",
     "conversion": {
-      "multiplier": 4448.221615260499999999999999999998,
+      "multiplier": 4448.22161526,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -3560,7 +3560,7 @@
     ],
     "symbol": "lbf",
     "conversion": {
-      "multiplier": 4.448221615260499999999999999999998,
+      "multiplier": 4.44822161526,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -3579,7 +3579,7 @@
     ],
     "symbol": "Mlbf",
     "conversion": {
-      "multiplier": 4448221.615260499999999999999999998,
+      "multiplier": 4448221.61526,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -3704,7 +3704,7 @@
     ],
     "symbol": "#/h",
     "conversion": {
-      "multiplier": 0.000277777777777778,
+      "multiplier": 0.000277777777778,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -3795,7 +3795,7 @@
     ],
     "symbol": "#/yr",
     "conversion": {
-      "multiplier": 3.168808781402895e-08,
+      "multiplier": 3.1688087814e-08,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -3818,7 +3818,7 @@
     ],
     "symbol": "/min",
     "conversion": {
-      "multiplier": 0.01666666666666666666666666666666667,
+      "multiplier": 0.0166666666667,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -4705,7 +4705,7 @@
     ],
     "symbol": "lbm/h",
     "conversion": {
-      "multiplier": 0.00012599788055555556,
+      "multiplier": 0.000125997880556,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -4756,7 +4756,7 @@
     ],
     "symbol": "lbm/min",
     "conversion": {
-      "multiplier": 0.007559872833333333,
+      "multiplier": 0.00755987283333,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -4838,7 +4838,7 @@
     ],
     "symbol": "t/day",
     "conversion": {
-      "multiplier": 0.011574074074074,
+      "multiplier": 0.0115740740741,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -4887,7 +4887,7 @@
     ],
     "symbol": "t/h",
     "conversion": {
-      "multiplier": 0.277777777777778,
+      "multiplier": 0.277777777778,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -4936,7 +4936,7 @@
     ],
     "symbol": "t/min",
     "conversion": {
-      "multiplier": 16.666666666666668,
+      "multiplier": 16.6666666667,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -5252,7 +5252,7 @@
     ],
     "symbol": "ft⋅lbf/h",
     "conversion": {
-      "multiplier": 0.0003766160967587223333333333333333332,
+      "multiplier": 0.000376616096759,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -5511,7 +5511,7 @@
     ],
     "symbol": "ft⋅lbf/s",
     "conversion": {
-      "multiplier": 1.355817948331400399999999999999999,
+      "multiplier": 1.35581794833,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -5567,7 +5567,7 @@
     ],
     "symbol": "GJ/h",
     "conversion": {
-      "multiplier": 2.777777777777777777777777777777778E5,
+      "multiplier": 277777.777778,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -5600,7 +5600,7 @@
     ],
     "symbol": "J/h",
     "conversion": {
-      "multiplier": 2.777777777777777777777777777777778E-4,
+      "multiplier": 0.000277777777778,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -5629,7 +5629,7 @@
     ],
     "symbol": "J/min",
     "conversion": {
-      "multiplier": 1.666666666666666666666666666666667E-2,
+      "multiplier": 0.0166666666667,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -6345,7 +6345,7 @@
     ],
     "symbol": "kpsi",
     "conversion": {
-      "multiplier": 6894757.293168361336722673445346887,
+      "multiplier": 6894757.29317,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -6480,7 +6480,7 @@
     ],
     "symbol": "lbf/ft²",
     "conversion": {
-      "multiplier": 47.88025898033584261612967670379783,
+      "multiplier": 47.8802589803,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -6809,7 +6809,7 @@
     ],
     "symbol": "psi",
     "conversion": {
-      "multiplier": 6894.757293168361336722673445346887,
+      "multiplier": 6894.75729317,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -7316,7 +7316,7 @@
     ],
     "symbol": "ft⋅lbf/ft²",
     "conversion": {
-      "multiplier": 14.59390293720636482939632545931758,
+      "multiplier": 14.5939029372,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -7882,7 +7882,7 @@
     ],
     "symbol": "°F",
     "conversion": {
-      "multiplier": 0.5555555555555556,
+      "multiplier": 0.555555555556,
       "offset": 459.67
     },
     "source": "qudt.org",
@@ -7918,7 +7918,7 @@
     ],
     "symbol": "°R",
     "conversion": {
-      "multiplier": 0.5555555555555556,
+      "multiplier": 0.555555555556,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -8211,7 +8211,7 @@
     ],
     "symbol": "lbf⋅ft",
     "conversion": {
-      "multiplier": 1.355817948331400399999999999999999,
+      "multiplier": 1.35581794833,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -8340,7 +8340,7 @@
     ],
     "symbol": "ft/h",
     "conversion": {
-      "multiplier": 8.466666666666667e-05,
+      "multiplier": 8.46666666667e-05,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -8489,7 +8489,7 @@
     ],
     "symbol": "km/h",
     "conversion": {
-      "multiplier": 0.2777777777777778,
+      "multiplier": 0.277777777778,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -8563,7 +8563,7 @@
     ],
     "symbol": "kn",
     "conversion": {
-      "multiplier": 0.5144444444444445,
+      "multiplier": 0.514444444444,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -8847,7 +8847,7 @@
     ],
     "quantity": "Velocity",
     "conversion": {
-      "multiplier": 3.168808781402895023702689684893655E-11,
+      "multiplier": 3.1688087814e-11,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -8880,7 +8880,7 @@
     ],
     "symbol": "mm/wk",
     "conversion": {
-      "multiplier": 1.6534391534391535e-09,
+      "multiplier": 1.65343915344e-09,
       "offset": 0.0
     },
     "source": "Custom based on qudt.org - https://qudt.org/vocab/unit/MilliM and https://qudt.org/vocab/unit/WK",
@@ -8913,7 +8913,7 @@
     ],
     "symbol": "m/min",
     "conversion": {
-      "multiplier": 0.016666666666666666,
+      "multiplier": 0.0166666666667,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -8946,7 +8946,7 @@
     ],
     "symbol": "km/wk",
     "conversion": {
-      "multiplier": 0.001653439153439153,
+      "multiplier": 0.00165343915344,
       "offset": 0.0
     },
     "source": "Custom based on qudt.org - https://qudt.org/vocab/unit/KiloM and https://qudt.org/vocab/unit/WK",
@@ -9731,7 +9731,7 @@
     ],
     "symbol": "ft³/min",
     "conversion": {
-      "multiplier": 0.0004719474432000001,
+      "multiplier": 0.0004719474432,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -9772,7 +9772,7 @@
     ],
     "symbol": "ft³/s",
     "conversion": {
-      "multiplier": 0.028316846592000004,
+      "multiplier": 0.028316846592,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -10001,7 +10001,7 @@
     ],
     "symbol": "kL/h",
     "conversion": {
-      "multiplier": 0.0002777777777777777777777777777777778,
+      "multiplier": 0.000277777777778,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -10189,7 +10189,7 @@
     ],
     "symbol": "Mm³/day",
     "conversion": {
-      "multiplier": 1.157407407407407407407407407407407e01,
+      "multiplier": 11.5740740741,
       "offset": 0.0
     },
     "source": "Custom based on qudt.org - https://qudt.org/vocab/unit/M3-PER-DAY",
@@ -10315,7 +10315,7 @@
     ],
     "symbol": "m³/h",
     "conversion": {
-      "multiplier": 0.0002777777777777778,
+      "multiplier": 0.000277777777778,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -11296,7 +11296,7 @@
     ],
     "symbol": "°/m",
     "conversion": {
-      "multiplier": 0.0174532925199433,
+      "multiplier": 0.0174532925199,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -11622,7 +11622,7 @@
     ],
     "symbol": "lbm/ft²",
     "conversion": {
-      "multiplier": 4.882427636383050543878865535508848,
+      "multiplier": 4.88242763638,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -11828,7 +11828,7 @@
     ],
     "symbol": "ft³/bbl",
     "conversion": {
-      "multiplier": 0.178107606679035,
+      "multiplier": 0.178107606679,
       "offset": 0.0
     },
     "source": "Energistics",
@@ -12068,7 +12068,7 @@
     ],
     "symbol": "kft³/bbl",
     "conversion": {
-      "multiplier": 178.107606679035,
+      "multiplier": 178.107606679,
       "offset": 0.0
     },
     "source": "Energistics",

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -700,7 +700,7 @@
     ],
     "symbol": "°",
     "conversion": {
-      "multiplier": 0.0174532925,
+      "multiplier": 0.017453292519943296,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -718,7 +718,7 @@
     ],
     "symbol": "grad",
     "conversion": {
-      "multiplier": 0.0157079633,
+      "multiplier": 0.015707963267949,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -791,7 +791,7 @@
     ],
     "symbol": "rev",
     "conversion": {
-      "multiplier": 6.28318531,
+      "multiplier": 6.2831853071795865,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -858,7 +858,7 @@
     ],
     "symbol": "rev/s²",
     "conversion": {
-      "multiplier": 6.28318531,
+      "multiplier": 6.2831853071795865,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -908,7 +908,7 @@
     ],
     "symbol": "rev/h",
     "conversion": {
-      "multiplier": 0.00174532925,
+      "multiplier": 0.0017453292519943296,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -960,7 +960,7 @@
     ],
     "symbol": "rev/min",
     "conversion": {
-      "multiplier": 0.104719755,
+      "multiplier": 0.10471975511965977,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -1002,7 +1002,7 @@
     ],
     "symbol": "rev/s",
     "conversion": {
-      "multiplier": 6.28318531,
+      "multiplier": 6.2831853071795865,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -1424,7 +1424,7 @@
     ],
     "symbol": "lbm/ft³",
     "conversion": {
-      "multiplier": 16.018463373960138,
+      "multiplier": 16.018463373960140,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -1504,7 +1504,7 @@
     ],
     "symbol": "lbm/in³",
     "conversion": {
-      "multiplier": 27679.904710203125,
+      "multiplier": 27679.904710203121,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -1555,7 +1555,7 @@
     ],
     "symbol": "lbm/yd³",
     "conversion": {
-      "multiplier": 0.5932764212577829,
+      "multiplier": 0.59327642125778295,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -1662,7 +1662,7 @@
     ],
     "symbol": "oz/in³",
     "conversion": {
-      "multiplier": 1729.99404,
+      "multiplier": 1729.9940443876951,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -1983,7 +1983,7 @@
     ],
     "symbol": "lbm/(ft⋅h)",
     "conversion": {
-      "multiplier": 0.0004133788732137649,
+      "multiplier": 0.00041337887321376495,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -2098,7 +2098,7 @@
     ],
     "symbol": "lbm/(ft⋅s)",
     "conversion": {
-      "multiplier": 1.4881639435695537,
+      "multiplier": 1.4881639435695538,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -2578,7 +2578,7 @@
     ],
     "symbol": "ft⋅lbf",
     "conversion": {
-      "multiplier": 1.3558179483314003,
+      "multiplier": 1.3558179483314004,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -3184,7 +3184,7 @@
     ],
     "symbol": "Btu{IT}/ft³",
     "conversion": {
-      "multiplier": 37258.94579,
+      "multiplier": 37258.945807831285,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -3234,7 +3234,7 @@
     ],
     "symbol": "Btu{th}/ft³",
     "conversion": {
-      "multiplier": 37234.028198530847,
+      "multiplier": 37234.028198530843,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -3470,7 +3470,7 @@
     ],
     "symbol": "klbf",
     "conversion": {
-      "multiplier": 4448.2216152604997,
+      "multiplier": 4448.2216152605,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -3560,7 +3560,7 @@
     ],
     "symbol": "lbf",
     "conversion": {
-      "multiplier": 4.4482216152604996,
+      "multiplier": 4.4482216152605,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -3579,7 +3579,7 @@
     ],
     "symbol": "Mlbf",
     "conversion": {
-      "multiplier": 4448221.6152605005,
+      "multiplier": 4448221.6152605,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -3704,7 +3704,7 @@
     ],
     "symbol": "#/h",
     "conversion": {
-      "multiplier": 0.000277777777777778,
+      "multiplier": 0.00027777777777777778,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -3818,7 +3818,7 @@
     ],
     "symbol": "/min",
     "conversion": {
-      "multiplier": 0.016666666666666666,
+      "multiplier": 0.016666666666666667,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -4452,7 +4452,7 @@
     ],
     "symbol": "g/min",
     "conversion": {
-      "multiplier": 1.666667e-05,
+      "multiplier": 0.000016666666666666667,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -4532,7 +4532,7 @@
     ],
     "symbol": "kg/day",
     "conversion": {
-      "multiplier": 1.157407e-05,
+      "multiplier": 0.000011574074074074074,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -4578,7 +4578,7 @@
     ],
     "symbol": "kg/h",
     "conversion": {
-      "multiplier": 0.000277777778,
+      "multiplier": 0.00027777777777777778,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -4619,7 +4619,7 @@
     ],
     "symbol": "kg/min",
     "conversion": {
-      "multiplier": 0.01666667,
+      "multiplier": 0.016666666666666667,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -4756,7 +4756,7 @@
     ],
     "symbol": "lbm/min",
     "conversion": {
-      "multiplier": 0.007559872833333333,
+      "multiplier": 0.0075598728333333333,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -4838,7 +4838,7 @@
     ],
     "symbol": "t/day",
     "conversion": {
-      "multiplier": 0.011574074074074,
+      "multiplier": 0.011574074074074074,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -4887,7 +4887,7 @@
     ],
     "symbol": "t/h",
     "conversion": {
-      "multiplier": 0.277777777777778,
+      "multiplier": 0.27777777777777778,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -4936,7 +4936,7 @@
     ],
     "symbol": "t/min",
     "conversion": {
-      "multiplier": 16.666666666666668,
+      "multiplier": 16.666666666666667,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -5065,7 +5065,7 @@
     ],
     "symbol": "Btu{IT}/h",
     "conversion": {
-      "multiplier": 0.29307107,
+      "multiplier": 0.29307107017222222,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -5252,7 +5252,7 @@
     ],
     "symbol": "ft⋅lbf/h",
     "conversion": {
-      "multiplier": 0.00037661609675872232,
+      "multiplier": 0.00037661609675872233,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -5397,7 +5397,7 @@
     ],
     "symbol": "ft⋅lbf/min",
     "conversion": {
-      "multiplier": 0.0225969678,
+      "multiplier": 0.022596965805523340,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -5511,7 +5511,7 @@
     ],
     "symbol": "ft⋅lbf/s",
     "conversion": {
-      "multiplier": 1.3558179483314003,
+      "multiplier": 1.3558179483314004,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -5567,7 +5567,7 @@
     ],
     "symbol": "GJ/h",
     "conversion": {
-      "multiplier": 277777.77777777775,
+      "multiplier": 277777.77777777778,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -5629,7 +5629,7 @@
     ],
     "symbol": "J/min",
     "conversion": {
-      "multiplier": 0.016666666666666666,
+      "multiplier": 0.016666666666666667,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -5706,7 +5706,7 @@
     ],
     "symbol": "kBtu{IT}/h",
     "conversion": {
-      "multiplier": 293.07107,
+      "multiplier": 293.07107017222222,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -5755,7 +5755,7 @@
     ],
     "symbol": "kcal/min",
     "conversion": {
-      "multiplier": 69.7333333,
+      "multiplier": 69.733333333333333,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -5869,7 +5869,7 @@
     ],
     "symbol": "MBtu{IT}/h",
     "conversion": {
-      "multiplier": 293071.07,
+      "multiplier": 293071.07017222222,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -6480,7 +6480,7 @@
     ],
     "symbol": "lbf/ft²",
     "conversion": {
-      "multiplier": 47.880258980335846,
+      "multiplier": 47.880258980335843,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -6809,7 +6809,7 @@
     ],
     "symbol": "psi",
     "conversion": {
-      "multiplier": 6894.7572931683617,
+      "multiplier": 6894.7572931683613,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -6830,7 +6830,7 @@
     ],
     "symbol": "psi(g)",
     "conversion": {
-      "multiplier": 6894.75789,
+      "multiplier": 6894.7572931683613,
       "offset": 14.6959475034
     },
     "source": "Experimental Methods and Instrumentation for Chemical Engineers - ISBN 9780444538055 - https://isbnsearch.org/isbn/9780444538055",
@@ -7316,7 +7316,7 @@
     ],
     "symbol": "ft⋅lbf/ft²",
     "conversion": {
-      "multiplier": 14.593902937206364,
+      "multiplier": 14.593902937206365,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -7882,7 +7882,7 @@
     ],
     "symbol": "°F",
     "conversion": {
-      "multiplier": 0.5555555555555556,
+      "multiplier": 0.55555555555555556,
       "offset": 459.67
     },
     "source": "qudt.org",
@@ -8211,7 +8211,7 @@
     ],
     "symbol": "lbf⋅ft",
     "conversion": {
-      "multiplier": 1.3558179483314003,
+      "multiplier": 1.3558179483314004,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -8263,7 +8263,7 @@
     ],
     "symbol": "lbf⋅in",
     "conversion": {
-      "multiplier": 0.112984839,
+      "multiplier": 0.11298482902761670,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -8340,7 +8340,7 @@
     ],
     "symbol": "ft/h",
     "conversion": {
-      "multiplier": 8.466666666666667e-05,
+      "multiplier": 0.000084666666666666667,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -8489,7 +8489,7 @@
     ],
     "symbol": "km/h",
     "conversion": {
-      "multiplier": 0.2777777777777778,
+      "multiplier": 0.27777777777777778,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -8563,7 +8563,7 @@
     ],
     "symbol": "kn",
     "conversion": {
-      "multiplier": 0.5144444444444445,
+      "multiplier": 0.51444444444444444,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -8640,7 +8640,7 @@
     ],
     "symbol": "m/h",
     "conversion": {
-      "multiplier": 0.000277777778,
+      "multiplier": 0.00027777777777777778,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -8828,7 +8828,7 @@
     ],
     "quantity": "Velocity",
     "conversion": {
-      "multiplier": 2.78e-7,
+      "multiplier": 2.7777777777777778E-7,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -8847,7 +8847,7 @@
     ],
     "quantity": "Velocity",
     "conversion": {
-      "multiplier": 3.1688087814028948e-11,
+      "multiplier": 3.168808781402895E-11,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -8913,7 +8913,7 @@
     ],
     "symbol": "m/min",
     "conversion": {
-      "multiplier": 0.016666666666666666,
+      "multiplier": 0.016666666666666667,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -9380,7 +9380,7 @@
     ],
     "symbol": "bbl/day",
     "conversion": {
-      "multiplier": 1.84e-06,
+      "multiplier": 0.0000018401307870370370,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -9431,7 +9431,7 @@
     ],
     "symbol": "bbl/h",
     "conversion": {
-      "multiplier": 4.4163e-5,
+      "multiplier": 0.000044163138888888889,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -9539,7 +9539,7 @@
     ],
     "symbol": "dm³/min",
     "conversion": {
-      "multiplier": 1.666667e-05,
+      "multiplier": 0.000016666666666666667,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -9634,7 +9634,7 @@
     ],
     "symbol": "ft³/day",
     "conversion": {
-      "multiplier": 3.277413e-07,
+      "multiplier": 3.2774128E-7,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -9683,7 +9683,7 @@
     ],
     "symbol": "ft³/h",
     "conversion": {
-      "multiplier": 7.865792e-06,
+      "multiplier": 0.00000786579072,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -9731,7 +9731,7 @@
     ],
     "symbol": "ft³/min",
     "conversion": {
-      "multiplier": 0.0004719474432000001,
+      "multiplier": 0.0004719474432,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -9772,7 +9772,7 @@
     ],
     "symbol": "ft³/s",
     "conversion": {
-      "multiplier": 0.028316846592000004,
+      "multiplier": 0.028316846592,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -9821,7 +9821,7 @@
     ],
     "symbol": "gal{UK}/h",
     "conversion": {
-      "multiplier": 1.262803e-06,
+      "multiplier": 0.0000012628027777777778,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -9870,7 +9870,7 @@
     ],
     "symbol": "gal{UK}/min",
     "conversion": {
-      "multiplier": 7.576817e-05,
+      "multiplier": 0.000075768166666666667,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -9952,7 +9952,7 @@
     ],
     "symbol": "in³/s",
     "conversion": {
-      "multiplier": 1.638706e-05,
+      "multiplier": 0.000016387064,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -10058,7 +10058,7 @@
     ],
     "symbol": "L/hr",
     "conversion": {
-      "multiplier": 2.777778e-07,
+      "multiplier": 2.7777777777777778E-7,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -10121,7 +10121,7 @@
     ],
     "symbol": "L/min",
     "conversion": {
-      "multiplier": 1.666667e-05,
+      "multiplier": 0.000016666666666666667,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -10241,7 +10241,7 @@
     ],
     "symbol": "m³/day",
     "conversion": {
-      "multiplier": 1.157407e-05,
+      "multiplier": 0.000011574074074074074,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -10315,7 +10315,7 @@
     ],
     "symbol": "m³/h",
     "conversion": {
-      "multiplier": 0.0002777777777777778,
+      "multiplier": 0.00027777777777777778,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -10374,7 +10374,7 @@
     ],
     "symbol": "m³/min",
     "conversion": {
-      "multiplier": 0.01666667,
+      "multiplier": 0.016666666666666667,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -10525,7 +10525,7 @@
     ],
     "symbol": "gal{US}/min",
     "conversion": {
-      "multiplier": 0.0000630902,
+      "multiplier": 0.0000630901964,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -11296,7 +11296,7 @@
     ],
     "symbol": "°/m",
     "conversion": {
-      "multiplier": 0.0174532925199433,
+      "multiplier": 0.017453292519943296,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -11391,7 +11391,7 @@
     ],
     "symbol": "L/day",
     "conversion": {
-      "multiplier": 0.00000001157407,
+      "multiplier": 1.1574074074074074E-8,
       "offset": 0
     },
     "source": "qudt.org",
@@ -11622,7 +11622,7 @@
     ],
     "symbol": "lbm/ft²",
     "conversion": {
-      "multiplier": 4.8824276363830501,
+      "multiplier": 4.8824276363830505,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -12121,7 +12121,7 @@
     ],
     "symbol": "lbm/d",
     "conversion": {
-      "multiplier": 0.000005249912,
+      "multiplier": 0.0000052499116898148148,
       "offset": 0.0
     },
     "source": "qudt.org",

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -1422,7 +1422,7 @@
       "pound mass / FT3",
       "Pound Mass per Cubic Foot"
     ],
-    "symbol": "lb/ft³",
+    "symbol": "lbm/ft³",
     "conversion": {
       "multiplier": 16.018463373960138,
       "offset": 0.0
@@ -1502,7 +1502,7 @@
       "LB / cubic inch",
       "lbm per cubic inch"
     ],
-    "symbol": "lb/in³",
+    "symbol": "lbm/in³",
     "conversion": {
       "multiplier": 27679.904710203125,
       "offset": 0.0
@@ -1553,7 +1553,7 @@
       "LB / Cubic Yard",
       "pound mass / Cubic Yard"
     ],
-    "symbol": "lb/yd³",
+    "symbol": "lbm/yd³",
     "conversion": {
       "multiplier": 0.5932764212577829,
       "offset": 0.0
@@ -1660,7 +1660,7 @@
       "OZ / IN3",
       "Ounce Mass / IN3"
     ],
-    "symbol": "oz/in³{US}",
+    "symbol": "oz/in³",
     "conversion": {
       "multiplier": 1729.99404,
       "offset": 0.0
@@ -1981,7 +1981,7 @@
       "Pound Mass / foot Hour",
       "LB / ft HR"
     ],
-    "symbol": "lb/(ft⋅h)",
+    "symbol": "lbm/(ft⋅h)",
     "conversion": {
       "multiplier": 0.0004133788732137649,
       "offset": 0.0
@@ -2096,7 +2096,7 @@
       "lbm / ft second",
       "pound mass per FT SEC"
     ],
-    "symbol": "lb/(ft⋅s)",
+    "symbol": "lbm/(ft⋅s)",
     "conversion": {
       "multiplier": 1.4881639435695537,
       "offset": 0.0
@@ -2578,7 +2578,7 @@
     ],
     "symbol": "ft⋅lbf",
     "conversion": {
-      "multiplier": 1.35581807,
+      "multiplier": 1.355817948331400399999999999999999,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -2665,7 +2665,7 @@
     ],
     "symbol": "kBtu{IT}",
     "conversion": {
-      "multiplier": 105505.585262,
+      "multiplier": 1055055.85262,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -2761,7 +2761,6 @@
       "Kilovolt ampere hour",
       "kilovolt ampere hour",
       "Kilovolt ampere HR",
-      "kV ⋅ A / hr",
       "kilovolt A hr",
       "kilovolt ampere hr",
       "Kilovolt ampere hr",
@@ -2769,7 +2768,7 @@
       "kV ampere HR",
       "kilovolt A Hour"
     ],
-    "symbol": "kV⋅A/h",
+    "symbol": "kV·A·h",
     "conversion": {
       "multiplier": 3600000.0,
       "offset": 0.0
@@ -2844,7 +2843,7 @@
       "Megaton of Oil Equivalent",
       "megaton of oil equivalent"
     ],
-    "symbol": "megatoe",
+    "symbol": "Mtoe",
     "conversion": {
       "multiplier": 4.1868e+16,
       "offset": 0.0
@@ -3235,7 +3234,7 @@
     ],
     "symbol": "Btu{th}/ft³",
     "conversion": {
-      "multiplier": 37234.03,
+      "multiplier": 37234.02819853084296428143745759641,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -3471,7 +3470,7 @@
     ],
     "symbol": "klbf",
     "conversion": {
-      "multiplier": 4448.222,
+      "multiplier": 4448.221615260499999999999999999998,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -3561,7 +3560,7 @@
     ],
     "symbol": "lbf",
     "conversion": {
-      "multiplier": 4.448222,
+      "multiplier": 4.448221615260499999999999999999998,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -3580,7 +3579,7 @@
     ],
     "symbol": "Mlbf",
     "conversion": {
-      "multiplier": 4448221.8148411428,
+      "multiplier": 4448221.615260499999999999999999998,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -3616,7 +3615,7 @@
     ],
     "symbol": "ozf",
     "conversion": {
-      "multiplier": 0.278013875,
+      "multiplier": 0.278013850954,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -4704,7 +4703,7 @@
       "pound mass per hr",
       "LB / hr"
     ],
-    "symbol": "lb/h",
+    "symbol": "lbm/h",
     "conversion": {
       "multiplier": 0.00012599788055555556,
       "offset": 0.0
@@ -4755,7 +4754,7 @@
       "pound mass / MIN",
       "lbm per min"
     ],
-    "symbol": "lb/min",
+    "symbol": "lbm/min",
     "conversion": {
       "multiplier": 0.007559872833333333,
       "offset": 0.0
@@ -5253,7 +5252,7 @@
     ],
     "symbol": "ft⋅lbf/h",
     "conversion": {
-      "multiplier": 0.00376616129,
+      "multiplier": 0.0003766160967587223333333333333333332,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -5512,7 +5511,7 @@
     ],
     "symbol": "ft⋅lbf/s",
     "conversion": {
-      "multiplier": 1.35581807,
+      "multiplier": 1.355817948331400399999999999999999,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -6346,7 +6345,7 @@
     ],
     "symbol": "kpsi",
     "conversion": {
-      "multiplier": 6894757.89,
+      "multiplier": 6894757.293168361336722673445346887,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -6481,7 +6480,7 @@
     ],
     "symbol": "lbf/ft²",
     "conversion": {
-      "multiplier": 47.8802631,
+      "multiplier": 47.88025898033584261612967670379783,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -6625,7 +6624,7 @@
       "\"WS",
       "\"H2O"
     ],
-    "symbol": "inH₂0",
+    "symbol": "inH₂O",
     "conversion": {
       "multiplier": 2.490889E2,
       "offset": 0.0
@@ -6810,7 +6809,7 @@
     ],
     "symbol": "psi",
     "conversion": {
-      "multiplier": 6894.75789,
+      "multiplier": 6894.757293168361336722673445346887,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -6856,8 +6855,8 @@
       "multiplier": 1.0,
       "offset": 0.0
     },
-    "source": "Custom based on qudt.org - https://qudt.org/vocab/unit/KiloPA-PER-M",
-    "sourceReference": null
+    "source": "qudt.org",
+    "sourceReference": "https://qudt.org/vocab/unit/PA-PER-M"
   },
   {
     "externalId": "pressure_gradient:bar-per-m",
@@ -7138,7 +7137,7 @@
       "offset": 0.0
     },
     "source": "Energistics: Unit of Measure Standard (revision June 2014) - https://www.energistics.org/energistics-unit-of-measure-standard",
-    "sourceReference": null
+    "sourceReference": "null"
   },
   {
     "externalId": "standard_volume:kilo_scf_1atm_60deg_f",
@@ -7317,7 +7316,7 @@
     ],
     "symbol": "ft⋅lbf/ft²",
     "conversion": {
-      "multiplier": 14.5939042,
+      "multiplier": 14.59390293720636482939632545931758,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -8212,7 +8211,7 @@
     ],
     "symbol": "lbf⋅ft",
     "conversion": {
-      "multiplier": 1.35581807,
+      "multiplier": 1.355817948331400399999999999999999,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -10002,7 +10001,7 @@
     ],
     "symbol": "kL/h",
     "conversion": {
-      "multiplier": 0.00277777777778,
+      "multiplier": 0.0002777777777777777777777777777777778,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -11157,9 +11156,9 @@
       "lbm / SEC",
       "LB / SEC"
     ],
-    "symbol": "lb/s",
+    "symbol": "lbm/s",
     "conversion": {
-      "multiplier": 0.4535924,
+      "multiplier": 0.45359237,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -11295,7 +11294,7 @@
       "deg/m",
       "deg.m-1"
     ],
-    "symbol": "deg/m",
+    "symbol": "°/m",
     "conversion": {
       "multiplier": 0.0174532925199433,
       "offset": 0.0
@@ -11312,7 +11311,7 @@
       "deg/30m",
       "deg.30m-1"
     ],
-    "symbol": "deg/30m",
+    "symbol": "°/30m",
     "conversion": {
       "multiplier": 0.000581776417,
       "offset": 0.0
@@ -11621,9 +11620,9 @@
       "lb/ft2",
       "lb/ft²"
     ],
-    "symbol": "lb/ft²",
+    "symbol": "lbm/ft²",
     "conversion": {
-      "multiplier": 4.882,
+      "multiplier": 4.882427636383050543878865535508848,
       "offset": 0.0
     },
     "source": "qudt.org",

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -1424,7 +1424,7 @@
     ],
     "symbol": "lbm/ft³",
     "conversion": {
-      "multiplier": 16.018463374,
+      "multiplier": 16.018463373960138,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -1504,7 +1504,7 @@
     ],
     "symbol": "lbm/in³",
     "conversion": {
-      "multiplier": 27679.9047102,
+      "multiplier": 27679.904710203125,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -1555,7 +1555,7 @@
     ],
     "symbol": "lbm/yd³",
     "conversion": {
-      "multiplier": 0.593276421258,
+      "multiplier": 0.5932764212577829,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -1983,7 +1983,7 @@
     ],
     "symbol": "lbm/(ft⋅h)",
     "conversion": {
-      "multiplier": 0.000413378873214,
+      "multiplier": 0.0004133788732137649,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -2098,7 +2098,7 @@
     ],
     "symbol": "lbm/(ft⋅s)",
     "conversion": {
-      "multiplier": 1.48816394357,
+      "multiplier": 1.4881639435695537,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -2282,7 +2282,7 @@
     ],
     "symbol": "A/h",
     "conversion": {
-      "multiplier": 0.000277777777778,
+      "multiplier": 0.0002777777777777778,
       "offset": 0.0
     },
     "source": "Custom based on qudt.org - https://qudt.org/vocab/unit/A and https://qudt.org/vocab/unit/HR",
@@ -2311,7 +2311,7 @@
     ],
     "symbol": "A/min",
     "conversion": {
-      "multiplier": 0.0166666666667,
+      "multiplier": 0.016666666666666666,
       "offset": 0.0
     },
     "source": "Custom based on qudt.org - https://qudt.org/vocab/unit/A and https://qudt.org/vocab/unit/MIN",
@@ -2578,7 +2578,7 @@
     ],
     "symbol": "ft⋅lbf",
     "conversion": {
-      "multiplier": 1.35581794833,
+      "multiplier": 1.355817948331400399999999999999999,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -3234,7 +3234,7 @@
     ],
     "symbol": "Btu{th}/ft³",
     "conversion": {
-      "multiplier": 37234.0281985,
+      "multiplier": 37234.02819853084296428143745759641,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -3470,7 +3470,7 @@
     ],
     "symbol": "klbf",
     "conversion": {
-      "multiplier": 4448.22161526,
+      "multiplier": 4448.221615260499999999999999999998,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -3560,7 +3560,7 @@
     ],
     "symbol": "lbf",
     "conversion": {
-      "multiplier": 4.44822161526,
+      "multiplier": 4.448221615260499999999999999999998,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -3579,7 +3579,7 @@
     ],
     "symbol": "Mlbf",
     "conversion": {
-      "multiplier": 4448221.61526,
+      "multiplier": 4448221.615260499999999999999999998,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -3704,7 +3704,7 @@
     ],
     "symbol": "#/h",
     "conversion": {
-      "multiplier": 0.000277777777778,
+      "multiplier": 0.000277777777777778,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -3795,7 +3795,7 @@
     ],
     "symbol": "#/yr",
     "conversion": {
-      "multiplier": 3.1688087814e-08,
+      "multiplier": 3.168808781402895e-08,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -3818,7 +3818,7 @@
     ],
     "symbol": "/min",
     "conversion": {
-      "multiplier": 0.0166666666667,
+      "multiplier": 0.01666666666666666666666666666666667,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -4705,7 +4705,7 @@
     ],
     "symbol": "lbm/h",
     "conversion": {
-      "multiplier": 0.000125997880556,
+      "multiplier": 0.00012599788055555556,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -4756,7 +4756,7 @@
     ],
     "symbol": "lbm/min",
     "conversion": {
-      "multiplier": 0.00755987283333,
+      "multiplier": 0.007559872833333333,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -4838,7 +4838,7 @@
     ],
     "symbol": "t/day",
     "conversion": {
-      "multiplier": 0.0115740740741,
+      "multiplier": 0.011574074074074,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -4887,7 +4887,7 @@
     ],
     "symbol": "t/h",
     "conversion": {
-      "multiplier": 0.277777777778,
+      "multiplier": 0.277777777777778,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -4936,7 +4936,7 @@
     ],
     "symbol": "t/min",
     "conversion": {
-      "multiplier": 16.6666666667,
+      "multiplier": 16.666666666666668,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -5252,7 +5252,7 @@
     ],
     "symbol": "ft⋅lbf/h",
     "conversion": {
-      "multiplier": 0.000376616096759,
+      "multiplier": 0.0003766160967587223333333333333333332,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -5511,7 +5511,7 @@
     ],
     "symbol": "ft⋅lbf/s",
     "conversion": {
-      "multiplier": 1.35581794833,
+      "multiplier": 1.355817948331400399999999999999999,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -5567,7 +5567,7 @@
     ],
     "symbol": "GJ/h",
     "conversion": {
-      "multiplier": 277777.777778,
+      "multiplier": 2.777777777777777777777777777777778E5,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -5600,7 +5600,7 @@
     ],
     "symbol": "J/h",
     "conversion": {
-      "multiplier": 0.000277777777778,
+      "multiplier": 2.777777777777777777777777777777778E-4,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -5629,7 +5629,7 @@
     ],
     "symbol": "J/min",
     "conversion": {
-      "multiplier": 0.0166666666667,
+      "multiplier": 1.666666666666666666666666666666667E-2,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -6345,7 +6345,7 @@
     ],
     "symbol": "kpsi",
     "conversion": {
-      "multiplier": 6894757.29317,
+      "multiplier": 6894757.293168361336722673445346887,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -6480,7 +6480,7 @@
     ],
     "symbol": "lbf/ft²",
     "conversion": {
-      "multiplier": 47.8802589803,
+      "multiplier": 47.88025898033584261612967670379783,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -6809,7 +6809,7 @@
     ],
     "symbol": "psi",
     "conversion": {
-      "multiplier": 6894.75729317,
+      "multiplier": 6894.757293168361336722673445346887,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -7316,7 +7316,7 @@
     ],
     "symbol": "ft⋅lbf/ft²",
     "conversion": {
-      "multiplier": 14.5939029372,
+      "multiplier": 14.59390293720636482939632545931758,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -7882,7 +7882,7 @@
     ],
     "symbol": "°F",
     "conversion": {
-      "multiplier": 0.555555555556,
+      "multiplier": 0.5555555555555556,
       "offset": 459.67
     },
     "source": "qudt.org",
@@ -7918,7 +7918,7 @@
     ],
     "symbol": "°R",
     "conversion": {
-      "multiplier": 0.555555555556,
+      "multiplier": 0.5555555555555556,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -8211,7 +8211,7 @@
     ],
     "symbol": "lbf⋅ft",
     "conversion": {
-      "multiplier": 1.35581794833,
+      "multiplier": 1.355817948331400399999999999999999,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -8340,7 +8340,7 @@
     ],
     "symbol": "ft/h",
     "conversion": {
-      "multiplier": 8.46666666667e-05,
+      "multiplier": 8.466666666666667e-05,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -8489,7 +8489,7 @@
     ],
     "symbol": "km/h",
     "conversion": {
-      "multiplier": 0.277777777778,
+      "multiplier": 0.2777777777777778,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -8563,7 +8563,7 @@
     ],
     "symbol": "kn",
     "conversion": {
-      "multiplier": 0.514444444444,
+      "multiplier": 0.5144444444444445,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -8847,7 +8847,7 @@
     ],
     "quantity": "Velocity",
     "conversion": {
-      "multiplier": 3.1688087814e-11,
+      "multiplier": 3.168808781402895023702689684893655E-11,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -8880,7 +8880,7 @@
     ],
     "symbol": "mm/wk",
     "conversion": {
-      "multiplier": 1.65343915344e-09,
+      "multiplier": 1.6534391534391535e-09,
       "offset": 0.0
     },
     "source": "Custom based on qudt.org - https://qudt.org/vocab/unit/MilliM and https://qudt.org/vocab/unit/WK",
@@ -8913,7 +8913,7 @@
     ],
     "symbol": "m/min",
     "conversion": {
-      "multiplier": 0.0166666666667,
+      "multiplier": 0.016666666666666666,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -8946,7 +8946,7 @@
     ],
     "symbol": "km/wk",
     "conversion": {
-      "multiplier": 0.00165343915344,
+      "multiplier": 0.001653439153439153,
       "offset": 0.0
     },
     "source": "Custom based on qudt.org - https://qudt.org/vocab/unit/KiloM and https://qudt.org/vocab/unit/WK",
@@ -9731,7 +9731,7 @@
     ],
     "symbol": "ft³/min",
     "conversion": {
-      "multiplier": 0.0004719474432,
+      "multiplier": 0.0004719474432000001,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -9772,7 +9772,7 @@
     ],
     "symbol": "ft³/s",
     "conversion": {
-      "multiplier": 0.028316846592,
+      "multiplier": 0.028316846592000004,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -10001,7 +10001,7 @@
     ],
     "symbol": "kL/h",
     "conversion": {
-      "multiplier": 0.000277777777778,
+      "multiplier": 0.0002777777777777777777777777777777778,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -10189,7 +10189,7 @@
     ],
     "symbol": "Mm³/day",
     "conversion": {
-      "multiplier": 11.5740740741,
+      "multiplier": 1.157407407407407407407407407407407e01,
       "offset": 0.0
     },
     "source": "Custom based on qudt.org - https://qudt.org/vocab/unit/M3-PER-DAY",
@@ -10315,7 +10315,7 @@
     ],
     "symbol": "m³/h",
     "conversion": {
-      "multiplier": 0.000277777777778,
+      "multiplier": 0.0002777777777777778,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -11296,7 +11296,7 @@
     ],
     "symbol": "°/m",
     "conversion": {
-      "multiplier": 0.0174532925199,
+      "multiplier": 0.0174532925199433,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -11622,7 +11622,7 @@
     ],
     "symbol": "lbm/ft²",
     "conversion": {
-      "multiplier": 4.88242763638,
+      "multiplier": 4.882427636383050543878865535508848,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -11828,7 +11828,7 @@
     ],
     "symbol": "ft³/bbl",
     "conversion": {
-      "multiplier": 0.178107606679,
+      "multiplier": 0.178107606679035,
       "offset": 0.0
     },
     "source": "Energistics",
@@ -12068,7 +12068,7 @@
     ],
     "symbol": "kft³/bbl",
     "conversion": {
-      "multiplier": 178.107606679,
+      "multiplier": 178.107606679035,
       "offset": 0.0
     },
     "source": "Energistics",

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -7137,7 +7137,7 @@
       "offset": 0.0
     },
     "source": "Energistics: Unit of Measure Standard (revision June 2014) - https://www.energistics.org/energistics-unit-of-measure-standard",
-    "sourceReference": "null"
+    "sourceReference": null
   },
   {
     "externalId": "standard_volume:kilo_scf_1atm_60deg_f",
@@ -11961,7 +11961,7 @@
       "offset": 0.0
     },
     "source": "Derived from base unit definitions in qudt.org (1 ft³ = 0.028316846592 m³; 1 bbl = 0.1589873 m³) and assumed standard conditions(scf @60°F/14.73 psia; STB @60°F/14.7 psia; Sm³ @15°C/101.325 kPa). Converts the ratio to the dimensionless SI base Sm³/Sm³.",
-    "sourceReference": "null"
+    "sourceReference": null
   },
   {
     "externalId": "liquid_gas_ratio:sm3-per-sm3",

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -2578,7 +2578,7 @@
     ],
     "symbol": "ft⋅lbf",
     "conversion": {
-      "multiplier": 1.355817948331400399999999999999999,
+      "multiplier": 1.3558179483314003,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -3234,7 +3234,7 @@
     ],
     "symbol": "Btu{th}/ft³",
     "conversion": {
-      "multiplier": 37234.02819853084296428143745759641,
+      "multiplier": 37234.028198530847,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -3470,7 +3470,7 @@
     ],
     "symbol": "klbf",
     "conversion": {
-      "multiplier": 4448.221615260499999999999999999998,
+      "multiplier": 4448.2216152604997,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -3560,7 +3560,7 @@
     ],
     "symbol": "lbf",
     "conversion": {
-      "multiplier": 4.448221615260499999999999999999998,
+      "multiplier": 4.4482216152604996,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -3579,7 +3579,7 @@
     ],
     "symbol": "Mlbf",
     "conversion": {
-      "multiplier": 4448221.615260499999999999999999998,
+      "multiplier": 4448221.6152605005,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -3818,7 +3818,7 @@
     ],
     "symbol": "/min",
     "conversion": {
-      "multiplier": 0.01666666666666666666666666666666667,
+      "multiplier": 0.016666666666666666,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -5252,7 +5252,7 @@
     ],
     "symbol": "ft⋅lbf/h",
     "conversion": {
-      "multiplier": 0.0003766160967587223333333333333333332,
+      "multiplier": 0.00037661609675872232,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -5511,7 +5511,7 @@
     ],
     "symbol": "ft⋅lbf/s",
     "conversion": {
-      "multiplier": 1.355817948331400399999999999999999,
+      "multiplier": 1.3558179483314003,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -5567,7 +5567,7 @@
     ],
     "symbol": "GJ/h",
     "conversion": {
-      "multiplier": 2.777777777777777777777777777777778E5,
+      "multiplier": 277777.77777777775,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -5600,7 +5600,7 @@
     ],
     "symbol": "J/h",
     "conversion": {
-      "multiplier": 2.777777777777777777777777777777778E-4,
+      "multiplier": 0.00027777777777777778,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -5629,7 +5629,7 @@
     ],
     "symbol": "J/min",
     "conversion": {
-      "multiplier": 1.666666666666666666666666666666667E-2,
+      "multiplier": 0.016666666666666666,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -6345,7 +6345,7 @@
     ],
     "symbol": "kpsi",
     "conversion": {
-      "multiplier": 6894757.293168361336722673445346887,
+      "multiplier": 6894757.2931683613,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -6480,7 +6480,7 @@
     ],
     "symbol": "lbf/ft²",
     "conversion": {
-      "multiplier": 47.88025898033584261612967670379783,
+      "multiplier": 47.880258980335846,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -6809,7 +6809,7 @@
     ],
     "symbol": "psi",
     "conversion": {
-      "multiplier": 6894.757293168361336722673445346887,
+      "multiplier": 6894.7572931683617,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -7316,7 +7316,7 @@
     ],
     "symbol": "ft⋅lbf/ft²",
     "conversion": {
-      "multiplier": 14.59390293720636482939632545931758,
+      "multiplier": 14.593902937206364,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -8211,7 +8211,7 @@
     ],
     "symbol": "lbf⋅ft",
     "conversion": {
-      "multiplier": 1.355817948331400399999999999999999,
+      "multiplier": 1.3558179483314003,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -8847,7 +8847,7 @@
     ],
     "quantity": "Velocity",
     "conversion": {
-      "multiplier": 3.168808781402895023702689684893655E-11,
+      "multiplier": 3.1688087814028948e-11,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -10001,7 +10001,7 @@
     ],
     "symbol": "kL/h",
     "conversion": {
-      "multiplier": 0.0002777777777777777777777777777777778,
+      "multiplier": 0.00027777777777777778,
       "offset": 0.0
     },
     "source": "qudt.org",
@@ -10189,7 +10189,7 @@
     ],
     "symbol": "Mm³/day",
     "conversion": {
-      "multiplier": 1.157407407407407407407407407407407e01,
+      "multiplier": 11.574074074074074,
       "offset": 0.0
     },
     "source": "Custom based on qudt.org - https://qudt.org/vocab/unit/M3-PER-DAY",
@@ -11622,7 +11622,7 @@
     ],
     "symbol": "lbm/ft²",
     "conversion": {
-      "multiplier": 4.882427636383050543878865535508848,
+      "multiplier": 4.8824276363830501,
       "offset": 0.0
     },
     "source": "qudt.org",


### PR DESCRIPTION
This PR updates existing units in the Cognite catalog to match the latest version of qudt.

Changes:
- Symbols updated to match the latest QUDT definitions where applicable
- `pressure_gradient:kilo-pa-per-m` is now available in qudt, so the source was set to `qudt.org` with a correct `sourceReference` URI
- Many QUDT conversion factors are updated to full-precision values 
- Fix conversion multipliers for the follwowing units: `energy:kilobtu_it`, `power:ft-lb_f-per-hr` and `volume_flow_rate:kilol-per-hr` (the current values are incorrect)