### PR TITLE
Automate Git tags and GitHub Releases on Maven Central publish (#76)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,11 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     environment: CD
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+
     - name: Set up Apache Maven Central
       uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
       with: # running setup-java again overwrites the settings.xml
@@ -31,7 +34,7 @@ jobs:
     - name: Detect version change
       id: detect
       run: |
-        CENTRAL_VERSION=$(curl -H "Accept: application/json" -L "https://central.sonatype.com/solrsearch/select?q=g:com.cognite.units+a:units-catalog&rows=1&wt=json" | jq -r '.response.docs[0].latestVersion')
+        CENTRAL_VERSION=$(curl -H "Accept: application/json" -L "https://central.sonatype.com/solrsearch/select?q=g:com.cognite.units+a:units-catalog&rows=1&wt=json" | ./jq -r '.response.docs[0].latestVersion')
         MVN_VERSION=$(mvn -q \
             -Dexec.executable=echo \
             -Dexec.args='${project.version}' \
@@ -42,7 +45,21 @@ jobs:
         echo "central_version=$CENTRAL_VERSION" >> $GITHUB_OUTPUT
         echo "maven_version=$MVN_VERSION" >> $GITHUB_OUTPUT
 
+    - name: Check if GitHub release exists for current version
+      id: gh_release_check
+      if: ${{ !endsWith(steps.detect.outputs.maven_version, 'SNAPSHOT') }}
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        V="${{ steps.detect.outputs.maven_version }}"
+        if gh release view "v${V}" >/dev/null 2>&1; then
+          echo "release_missing=false" >> $GITHUB_OUTPUT
+        else
+          echo "release_missing=true" >> $GITHUB_OUTPUT
+        fi
+
     - name: Publish to Apache Maven Central
+      id: maven_deploy
       if: ${{ !endsWith(steps.detect.outputs.maven_version, 'SNAPSHOT') && steps.detect.outputs.maven_version != steps.detect.outputs.central_version }}
       run: |
         mvn -B clean deploy -P release
@@ -50,3 +67,66 @@ jobs:
         MAVEN_USERNAME: ${{ secrets.SONATYPE_CENTRAL_PORTAL_USER }}
         MAVEN_CENTRAL_TOKEN: ${{ secrets.SONATYPE_CENTRAL_PORTAL_PASSWORD }}
         MAVEN_GPG_PASSPHRASE: ${{ secrets.SONATYPE_CENTRAL_PORTAL_GPG_KEY_PASSPHRASE }}
+
+    - name: Prepare GitHub release notes
+      if: >-
+        ${{ !endsWith(steps.detect.outputs.maven_version, 'SNAPSHOT')
+        && steps.gh_release_check.outputs.release_missing == 'true'
+        && (steps.maven_deploy.outcome == 'success'
+            || steps.detect.outputs.maven_version == steps.detect.outputs.central_version) }}
+      run: |
+        VERSION="${{ steps.detect.outputs.maven_version }}"
+        awk -v v="$VERSION" '
+          $0 ~ "^## \\["v"\\]" {flag=1; next}
+          flag && /^## \[/ {exit}
+          flag {print}
+        ' CHANGELOG.md > RELEASE_NOTES.md
+        if [ ! -s RELEASE_NOTES.md ]; then
+          echo "CHANGELOG.md has no section for version ${VERSION}"
+          exit 1
+        fi
+        {
+          echo ""
+          echo "---"
+          echo "Maven Central: https://central.sonatype.com/artifact/com.cognite.units/units-catalog/${VERSION}"
+        } >> RELEASE_NOTES.md
+
+    - name: Wait for Maven Central index (optional)
+      if: >-
+        ${{ !endsWith(steps.detect.outputs.maven_version, 'SNAPSHOT')
+        && steps.gh_release_check.outputs.release_missing == 'true'
+        && (steps.maven_deploy.outcome == 'success'
+            || steps.detect.outputs.maven_version == steps.detect.outputs.central_version) }}
+      continue-on-error: true
+      run: |
+        VERSION="${{ steps.detect.outputs.maven_version }}"
+        for i in $(seq 1 24); do
+          LATEST=$(curl -s -H "Accept: application/json" -L "https://central.sonatype.com/solrsearch/select?q=g:com.cognite.units+a:units-catalog&rows=1&wt=json" | ./jq -r '.response.docs[0].latestVersion')
+          if [ "$LATEST" = "$VERSION" ]; then
+            echo "Maven Central lists latestVersion=$VERSION"
+            exit 0
+          fi
+          echo "Attempt $i/24: latestVersion=$LATEST (want $VERSION), waiting 5s..."
+          sleep 5
+        done
+        echo "Timeout waiting for Central index; continuing."
+
+    - name: Create GitHub Release
+      if: >-
+        ${{ !endsWith(steps.detect.outputs.maven_version, 'SNAPSHOT')
+        && steps.gh_release_check.outputs.release_missing == 'true'
+        && (steps.maven_deploy.outcome == 'success'
+            || steps.detect.outputs.maven_version == steps.detect.outputs.central_version) }}
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        VERSION="${{ steps.detect.outputs.maven_version }}"
+        if gh release view "v${VERSION}" >/dev/null 2>&1; then
+          echo "Release v${VERSION} already exists, skipping."
+          exit 0
+        fi
+        gh release create "v${VERSION}" \
+          --title "v${VERSION}" \
+          --notes-file RELEASE_NOTES.md \
+          --target "${GITHUB_SHA}" \
+          --latest

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ The test suite includes duplicate detection (`DuplicatedUnitsTest`) that identif
 
 Known equivalent units are whitelisted in `src/test/kotlin/EquivalentUnits.kt`. The CI pipeline runs duplicate detection on every PR and posts results as a comment.
 
+## Releasing
+
+Maven Central publication, Git tags, and GitHub Releases are automated from `main` when the version in `pom.xml` is bumped. Maintainer steps and retry/backfill instructions are in [RELEASING.md](RELEASING.md).
+
 ## Attribution
 Some of the units are sourced from QUDT.org, which is licensed under the [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).
 These are marked with the `qudt.org` source.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,23 @@
+# Releasing units-catalog
+
+Production releases are published to [Maven Central](https://central.sonatype.com/artifact/com.cognite.units/units-catalog) as `com.cognite.units:units-catalog`. Git tags (`vX.Y.Z`) and [GitHub Releases](https://github.com/cognitedata/units-catalog/releases) are created automatically by CI when a new version ships.
+
+## Steps (maintainers)
+
+1. **Changelog** — Add a section to [CHANGELOG.md](CHANGELOG.md) for the new version:
+
+   `## [X.Y.Z] - YYYY-MM-DD`
+
+   Follow the existing *Added* / *Changed* / *Fixed* structure.
+
+2. **Version** — Set `<version>X.Y.Z</version>` in the root [pom.xml](pom.xml) to match the changelog entry.
+
+3. **Merge to `main`** — Open a PR and merge. The workflow [.github/workflows/release.yml](.github/workflows/release.yml) runs when `pom.xml` (or the workflow file) changes on `main`.
+
+4. **CI** — If the POM version is newer than the latest version on Maven Central, the job deploys the artifact, then creates a GitHub Release whose notes are the changelog section for that version plus a link to the Maven Central artifact page.
+
+Do **not** create Git tags or GitHub releases manually for normal releases; automation handles it.
+
+## Retrying a failed GitHub Release
+
+If Maven Central deployment succeeded but the GitHub Release step failed, fix the workflow or re-run the job: once Central lists the new version, CI can create the missing release without redeploying (same `pom.xml` version on `main`).


### PR DESCRIPTION
Extends the existing Maven Central release workflow to also create a `vX.Y.Z` Git tag and a GitHub Release whenever a new version is published, closing [#76](https://github.com/cognitedata/units-catalog/issues/76).

## Changes
- **`.github/workflows/release.yml`**
  - Grants the job `contents: write`.
  - After a successful `mvn deploy -P release` (or when the current `pom.xml` version is already on Central but has no GitHub release), the workflow:
    - extracts the matching section from `CHANGELOG.md`,
    - appends a link to the Maven Central artifact,
    - polls Central for up to ~2 min so the link resolves (non-blocking),
    - runs `gh release create vX.Y.Z --latest --target $GITHUB_SHA`, which creates both the tag and the release.
  - Idempotent: a `gh release view` guard and a pre-check output skip steps when a release already exists, so re-runs and subsequent pushes are safe.
- **`RELEASING.md`** — new maintainer doc: bump `CHANGELOG.md` + `pom.xml`, merge to `main`, CI does the rest.
- **`README.md`** — added a short *Releasing* section pointing to `RELEASING.md`.

## Behavior
- First push of `pom.xml` after this lands will auto-create a GitHub Release for the current version if one doesn't exist yet (no redeploy).
- Fails fast if the CHANGELOG section for the version being released is missing.

## Test plan
- [ ] Workflow YAML parses (actionlint) and renders the correct `if:` gating.
- [ ] On next version bump: tag `vX.Y.Z` appears, GitHub Release shows the CHANGELOG section plus the Maven Central link, and is marked "Latest".
- [ ] Re-running the workflow for the same version does not create a duplicate release.