### PR TITLE
Fix release workflow: install jq via apt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
     - name: Set up Apache Maven Central
-      uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with: # running setup-java again overwrites the settings.xml
         distribution: "temurin"
         java-version: "17"
@@ -27,14 +27,12 @@ jobs:
         gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
     - name: Install jq
-      run: |
-        curl http://stedolan.github.io/jq/download/linux64/jq -o ./jq
-        chmod a+x ./jq
+      run: sudo apt-get update && sudo apt-get install -y jq
 
     - name: Detect version change
       id: detect
       run: |
-        CENTRAL_VERSION=$(curl -H "Accept: application/json" -L "https://central.sonatype.com/solrsearch/select?q=g:com.cognite.units+a:units-catalog&rows=1&wt=json" | ./jq -r '.response.docs[0].latestVersion')
+        CENTRAL_VERSION=$(curl -H "Accept: application/json" -L "https://central.sonatype.com/solrsearch/select?q=g:com.cognite.units+a:units-catalog&rows=1&wt=json" | jq -r '.response.docs[0].latestVersion')
         MVN_VERSION=$(mvn -q \
             -Dexec.executable=echo \
             -Dexec.args='${project.version}' \
@@ -101,7 +99,7 @@ jobs:
       run: |
         VERSION="${{ steps.detect.outputs.maven_version }}"
         for i in $(seq 1 24); do
-          LATEST=$(curl -s -H "Accept: application/json" -L "https://central.sonatype.com/solrsearch/select?q=g:com.cognite.units+a:units-catalog&rows=1&wt=json" | ./jq -r '.response.docs[0].latestVersion')
+          LATEST=$(curl -s -H "Accept: application/json" -L "https://central.sonatype.com/solrsearch/select?q=g:com.cognite.units+a:units-catalog&rows=1&wt=json" | jq -r '.response.docs[0].latestVersion')
           if [ "$LATEST" = "$VERSION" ]; then
             echo "Maven Central lists latestVersion=$VERSION"
             exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
     - name: Set up Apache Maven Central
-      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
       with: # running setup-java again overwrites the settings.xml
         distribution: "temurin"
         java-version: "17"


### PR DESCRIPTION
## Summary

- Replace the dead `curl` jq install with `sudo apt-get install -y jq`. The old URL now returns a 301 to an HTML page.

## Test plan

- [ ] Workflow YAML parses.
- [ ] Merging this PR triggers the workflow (it edits `release.yml`); it should reach `Detect version change` cleanly, then short-circuit `Publish to Apache Maven Central` (because `maven_version == central_version` for `0.1.25`) and `Create GitHub Release` (release `v0.1.25` already exists), finishing green.