### PR TITLE
adding electric_conductivity units

### DIFF
--- a/versions/v1/unitSystems.json
+++ b/versions/v1/unitSystems.json
@@ -55,6 +55,10 @@
         "unitExternalId": "dynamic_viscosity:pa-sec"
       },
       {
+        "name": "Electric Conductivity",
+        "unitExternalId": "electric_conductivity:s-per-m"
+      },
+      {
         "name": "Electric Current",
         "unitExternalId": "electric_current:a"
       },

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -2221,8 +2221,8 @@
     "sourceReference": "https://qudt.org/vocab/unit/MicroS-PER-CentiM"
   },
   {
-    "externalId": "electric_conductivity:millis-per-cm",
-    "name": "MilliS-PER-CM",
+    "externalId": "electric_conductivity:millis-per-centim",
+    "name": "MilliS-PER-CentiM",
     "quantity": "Electric Conductivity",
     "longName": "Millisiemens Per Centimeter",
     "aliasNames": [

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -2199,8 +2199,8 @@
     "sourceReference": "https://qudt.org/vocab/unit/S-PER-M"
   },
   {
-    "externalId": "electric_conductivity:micros-per-cm",
-    "name": "MicroS-PER-CM",
+    "externalId": "electric_conductivity:micros-per-centim",
+    "name": "MicroS-PER-CentiM",
     "quantity": "Electric Conductivity",
     "longName": "Microsiemens Per Centimeter",
     "aliasNames": [

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -2178,6 +2178,69 @@
     "sourceReference": "https://qudt.org/vocab/unit/POISE"
   },
   {
+    "externalId": "electric_conductivity:s-per-m",
+    "name": "S-PER-M",
+    "quantity": "Electric Conductivity",
+    "longName": "Siemens Per Meter",
+    "aliasNames": [
+      "S/m",
+      "S per m",
+      "siemens per meter",
+      "Siemens per Meter",
+      "Siemens Per Meter",
+      "mho/m"
+    ],
+    "symbol": "S/m",
+    "conversion": {
+      "multiplier": 1.0,
+      "offset": 0.0
+    },
+    "source": "qudt.org",
+    "sourceReference": "https://qudt.org/vocab/unit/S-PER-M"
+  },
+  {
+    "externalId": "electric_conductivity:micros-per-cm",
+    "name": "MicroS-PER-CM",
+    "quantity": "Electric Conductivity",
+    "longName": "Microsiemens Per Centimeter",
+    "aliasNames": [
+      "µS/cm",
+      "uS/cm",
+      "μS/cm",
+      "microsiemens per centimeter",
+      "Microsiemens per Centimeter",
+      "Microsiemens Per Centimeter",
+      "µmho/cm"
+    ],
+    "symbol": "µS/cm",
+    "conversion": {
+      "multiplier": 0.0001,
+      "offset": 0.0
+    },
+    "source": "Custom based on qudt.org",
+    "sourceReference": null
+  },
+  {
+    "externalId": "electric_conductivity:millis-per-cm",
+    "name": "MilliS-PER-CM",
+    "quantity": "Electric Conductivity",
+    "longName": "Millisiemens Per Centimeter",
+    "aliasNames": [
+      "mS/cm",
+      "millisiemens per centimeter",
+      "Millisiemens per Centimeter",
+      "Millisiemens Per Centimeter",
+      "mmho/cm"
+    ],
+    "symbol": "mS/cm",
+    "conversion": {
+      "multiplier": 0.1,
+      "offset": 0.0
+    },
+    "source": "Custom based on qudt.org",
+    "sourceReference": null
+  },
+  {
     "externalId": "electric_current:a",
     "name": "A",
     "quantity": "Electric Current",

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -2217,8 +2217,8 @@
       "multiplier": 0.0001,
       "offset": 0.0
     },
-    "source": "Custom based on qudt.org",
-    "sourceReference": null
+    "source": "qudt.org",
+    "sourceReference": "https://qudt.org/vocab/unit/MicroS-PER-CentiM"
   },
   {
     "externalId": "electric_conductivity:millis-per-cm",

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -2237,8 +2237,8 @@
       "multiplier": 0.1,
       "offset": 0.0
     },
-    "source": "Custom based on qudt.org",
-    "sourceReference": null
+    "source": "qudt.org",
+    "sourceReference": "https://qudt.org/vocab/unit/MilliS-PER-CentiM"
   },
   {
     "externalId": "electric_current:a",


### PR DESCRIPTION
## Summary

Adds three units for the `Electric Conductivity` quantity:

| externalId | Symbol | Long name |
|---|---|---|
| `electric_conductivity:s-per-m` | S/m | Siemens Per Meter |
| `electric_conductivity:micros-per-cm` | µS/cm | Microsiemens Per Centimeter |
| `electric_conductivity:millis-per-cm` | mS/cm | Millisiemens Per Centimeter |

`electric_conductivity:s-per-m` (SI base unit) is registered as the default for the `Electric Conductivity` quantity in the Default unit system.

## Rationale

Environmental monitoring use cases require electrical conductivity measurements in the units commonly used by field sensors (µS/cm and mS/cm), which are orders of magnitude smaller than the SI base unit. All three units are needed so that time series data can be stored in the unit the instrument reports without a silent unit mismatch.

## Use cases

Requested to support environmental monitoring workflows that include:

- **Biosphere** – Soil and surface electrical conductivity sensors reporting in µS/cm and mS/cm
- **Hydrosphere** – Water electrical conductivity sensors reporting in µS/cm and mS/cm
