### PR TITLE
Add molar flux quantity and units

### DIFF
--- a/versions/v1/unitSystems.json
+++ b/versions/v1/unitSystems.json
@@ -111,6 +111,10 @@
         "unitExternalId": "mass_flow_rate:kilogm-per-sec"
       },
       {
+        "name": "Molar Flux",
+        "unitExternalId": "molar_flux:mol-per-m2-sec"
+      },
+      {
         "name": "Permeability",
         "unitExternalId": "permeability:h-per-m"
       },

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -12128,6 +12128,47 @@
     "sourceReference": "https://qudt.org/vocab/unit/LB-PER-DAY"
   },
   {
+    "externalId": "molar_flux:mol-per-m2-sec",
+    "name": "MOL-PER-M2-SEC",
+    "quantity": "Molar Flux",
+    "longName": "Mole Per Square Meter Per Second",
+    "aliasNames": [
+      "mol/(m²·s)",
+      "mol/m²/s",
+      "mol/m2/s",
+      "mole per square meter per second",
+      "Mole per Square Meter per Second"
+    ],
+    "symbol": "mol/(m²·s)",
+    "conversion": {
+      "multiplier": 1.0,
+      "offset": 0.0
+    },
+    "source": "qudt.org",
+    "sourceReference": "https://qudt.org/vocab/unit/MOL-PER-M2-SEC"
+  },
+  {
+    "externalId": "molar_flux:micromol-per-m2-sec",
+    "name": "MicroMOL-PER-M2-SEC",
+    "quantity": "Molar Flux",
+    "longName": "Micromole Per Square Meter Per Second",
+    "aliasNames": [
+      "µmol/(m²·s)",
+      "µmol/m²/s",
+      "umol/m2/s",
+      "umol m-2 s-1",
+      "micromole per square meter per second",
+      "Micromole per Square Meter per Second"
+    ],
+    "symbol": "µmol/(m²·s)",
+    "conversion": {
+      "multiplier": 1e-06,
+      "offset": 0.0
+    },
+    "source": "Custom based on qudt.org",
+    "sourceReference": null
+  },
+  {
     "externalId": "volume_per_time_per_pressure:m3-per-sec-per-pa",
     "name": "M3-PER-SEC-PER-PA",
     "quantity": "Volume per time per pressure",

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -12165,8 +12165,8 @@
       "multiplier": 1e-06,
       "offset": 0.0
     },
-    "source": "Custom based on qudt.org",
-    "sourceReference": null
+    "source": "qudt.org",
+    "sourceReference": "https://qudt.org/vocab/unit/MicroMOL-PER-M2-SEC"
   },
   {
     "externalId": "volume_per_time_per_pressure:m3-per-sec-per-pa",


### PR DESCRIPTION
## Summary

Adds two units for the `Molar Flux` quantity:

| externalId | Symbol | Long name |
|---|---|---|
| `molar_flux:mol-per-m2-sec` | mol/(m²·s) | Mole Per Square Meter Per Second |
| `molar_flux:micromol-per-m2-sec` | µmol/(m²·s) | Micromole Per Square Meter Per Second |

`molar_flux:mol-per-m2-sec` (SI base unit) is registered as the default for the `Molar Flux` quantity in the Default unit system.

## Rationale

Atmospheric and soil CO₂ flux sensors report in µmol/(m²·s), which is the standard unit in eddy covariance and gas exchange measurements. Both the SI base unit and the micromole-scale unit are needed so that time series data can be stored in the unit the instrument reports without a silent unit mismatch.

## Use cases

Requested to support environmental monitoring workflows that include:

- **Atmospheric** – CO₂ flux sensors reporting in µmol/(m²·s)
- **Biosphere** – Soil CO₂ flux sensors reporting in µmol/(m²·s)
