### PR TITLE
Add revolutions per unit volume quantity and units for mud motor speed ratio

### DIFF
--- a/versions/v1/unitSystems.json
+++ b/versions/v1/unitSystems.json
@@ -245,6 +245,10 @@
       {
         "name": "Reservoir Volume Flow Rate",
         "unitExternalId": "reservoir_volume_flow_rate:rb-per-day"
+      },
+      {
+        "name": "Revolutions Per Unit Volume",
+        "unitExternalId": "revolutions_per_unit_volume:rev-per-gal_us"
       }
     ]
   },
@@ -442,6 +446,10 @@
       {
         "name": "Volume per time per pressure",
         "unitExternalId": "volume_per_time_per_pressure:m3-per-sec-per-pa"
+      },
+      {
+        "name": "Revolutions Per Unit Volume",
+        "unitExternalId": "revolutions_per_unit_volume:rev-per-l"
       }
     ]
   },
@@ -559,6 +567,10 @@
       {
         "name": "Linear Density",
         "unitExternalId": "linear_density:lb-per-ft"
+      },
+      {
+        "name": "Revolutions Per Unit Volume",
+        "unitExternalId": "revolutions_per_unit_volume:rev-per-gal_us"
       }
     ]
   }

--- a/versions/v1/unitSystems.json
+++ b/versions/v1/unitSystems.json
@@ -449,7 +449,7 @@
       },
       {
         "name": "Revolutions Per Unit Volume",
-        "unitExternalId": "revolutions_per_unit_volume:rev-per-l"
+        "unitExternalId": "revolutions_per_unit_volume:rev-per-m3"
       }
     ]
   },

--- a/versions/v1/units.json
+++ b/versions/v1/units.json
@@ -12249,6 +12249,95 @@
     "sourceReference": "https://qudt.org/vocab/unit/MicroMOL-PER-M2-SEC"
   },
   {
+    "externalId": "revolutions_per_unit_volume:rev-per-m3",
+    "name": "REV-PER-M3",
+    "quantity": "Revolutions Per Unit Volume",
+    "longName": "Revolution Per Cubic Meter",
+    "aliasNames": [
+      "rev/m3",
+      "rev/m³",
+      "rev per m3",
+      "rev per cubic meter",
+      "revolutions per cubic meter",
+      "Revolution Per Cubic Meter"
+    ],
+    "symbol": "rev/m³",
+    "conversion": {
+      "multiplier": 1.0,
+      "offset": 0.0
+    },
+    "source": "Custom based on qudt.org - https://qudt.org/vocab/unit/REV and https://qudt.org/vocab/unit/M3",
+    "sourceReference": null
+  },
+  {
+    "externalId": "revolutions_per_unit_volume:rev-per-l",
+    "name": "REV-PER-L",
+    "quantity": "Revolutions Per Unit Volume",
+    "longName": "Revolution Per Liter",
+    "aliasNames": [
+      "rev/l",
+      "rev/L",
+      "revs/L",
+      "rev per l",
+      "rev per liter",
+      "rev per litre",
+      "revolutions per liter",
+      "revolutions per litre",
+      "Revolution Per Liter"
+    ],
+    "symbol": "rev/L",
+    "conversion": {
+      "multiplier": 1000.0,
+      "offset": 0.0
+    },
+    "source": "Custom based on qudt.org - https://qudt.org/vocab/unit/REV and https://qudt.org/vocab/unit/L",
+    "sourceReference": null
+  },
+  {
+    "externalId": "revolutions_per_unit_volume:rev-per-gal_us",
+    "name": "REV-PER-GAL_US",
+    "quantity": "Revolutions Per Unit Volume",
+    "longName": "Revolution Per US Gallon",
+    "aliasNames": [
+      "rev/gal",
+      "revs/gal",
+      "Rev/Gal",
+      "RPG",
+      "rev per gal",
+      "revolutions per gallon",
+      "motor speed ratio",
+      "speed ratio",
+      "Revolution Per US Gallon"
+    ],
+    "symbol": "rev/gal{US}",
+    "conversion": {
+      "multiplier": 264.1720523581484,
+      "offset": 0.0
+    },
+    "source": "Custom based on qudt.org - https://qudt.org/vocab/unit/REV and https://qudt.org/vocab/unit/GAL_US",
+    "sourceReference": null
+  },
+  {
+    "externalId": "revolutions_per_unit_volume:rev-per-gal_uk",
+    "name": "REV-PER-GAL_UK",
+    "quantity": "Revolutions Per Unit Volume",
+    "longName": "Revolution Per UK Gallon",
+    "aliasNames": [
+      "rev/gal{UK}",
+      "revs per UK gallon",
+      "rev per UK gallon",
+      "revolutions per UK gallon",
+      "Revolution Per UK Gallon"
+    ],
+    "symbol": "rev/gal{UK}",
+    "conversion": {
+      "multiplier": 219.96924829908778,
+      "offset": 0.0
+    },
+    "source": "Custom based on qudt.org - https://qudt.org/vocab/unit/REV and https://qudt.org/vocab/unit/GAL_UK",
+    "sourceReference": null
+  },
+  {
     "externalId": "volume_per_time_per_pressure:m3-per-sec-per-pa",
     "name": "M3-PER-SEC-PER-PA",
     "quantity": "Volume per time per pressure",


### PR DESCRIPTION
## Summary
- Add new quantity **Revolutions Per Unit Volume** for mud motor speed ratio (RPG / rev/gal)
- Add units: `rev-per-m3` (base), `rev-per-l` (metric), `rev-per-gal_us` (US), `rev-per-gal_uk` (UK)
- Set Default and Imperial system units to `rev-per-gal_us`; SI to `rev-per-m3`

## Rationale
Mud motor OEM spec sheets express motor displacement as revolutions per gallon of flow (Rev/Gal, RPG, Speed Ratio). This quantity is needed for SLB Bits data model. QUDT does not define rev/gal or rev/L compound units; entries are derived from QUDT REV, GAL_US, GAL_UK, and L.

## Customer / use case
- Needed for Bits data model under CDF Project: **slb-wodf-wec-eu**
- Motor RPM estimation: motor_rpm = flow_rate × rev_per_unit_volume

## References
- IADC Drilling Manual — Downhole Mud Motors (rev proportional to flow × cavity volume)
- AADE-22-FTCE-078 — motor model using revolutions per gallon
- Motor OEM spec sheets (Rev/Gal column)

## Test plan
- [ ] `mvn verify` passes in CI
- [ ] Confirm conversion: 1 rev/gal{US} → 0.264172 rev/L
- [ ] Confirm conversion: 1 rev/gal{UK} → 0.219969 rev/L

Made with [Cursor](https://cursor.com)